### PR TITLE
Fixed typo in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1540,7 +1540,7 @@
           "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
-            "is-fullwi dth-code-point": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
             "strip-ansi": "^3.0.0"
           }
         },


### PR DESCRIPTION
## Description

Dependency typo fix for a specified node package. 

- Affected package : 'String-width'
- Affected depencency: 'is-fullwidth-code-point' 

**'String-width'** is a npm package that measures the actual width of command-line output for a given string.
It has 3 dependencies - emoji-regex, is-fullwidth-code-point and strip-ansi.
Dependency **'is-fullwidth-code-point'** checks if the character represented by a given Unicode code point is fullwidth or not.

This PR fixes the typo introduced in *commit e07ec31.*
 
## Type of change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have performed a self-review by myself
- [ ] PR follows the contribution template of this project
- [ ] My changes generate no new warnings

*Note: Please add a purple **SCI-2020** label while reviewing the PR, as guided by the authorities*