### PR TITLE
Voter Registration Feature Successfully Added

### DIFF
--- a/build/contracts/Election.json
+++ b/build/contracts/Election.json
@@ -110,6 +110,18 @@
       "type": "event"
     },
     {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "_nationalID",
+          "type": "uint256"
+        }
+      ],
+      "name": "newVoter",
+      "type": "event"
+    },
+    {
       "constant": false,
       "inputs": [
         {
@@ -138,21 +150,21 @@
       "type": "function"
     }
   ],
-  "metadata": "{\"compiler\":{\"version\":\"0.4.23+commit.124ca40d\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"constant\":false,\"inputs\":[{\"name\":\"_candidateId\",\"type\":\"uint256\"}],\"name\":\"vote\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"candidatesCount\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"candidates\",\"outputs\":[{\"name\":\"id\",\"type\":\"uint256\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"voteCount\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"votersCount\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"address\"}],\"name\":\"voters\",\"outputs\":[{\"name\":\"NID\",\"type\":\"uint256\"},{\"name\":\"eligibility\",\"type\":\"bool\"},{\"name\":\"hasVoted\",\"type\":\"bool\"},{\"name\":\"blindedVote\",\"type\":\"uint256\"},{\"name\":\"signedBlindedVote\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_nationalID\",\"type\":\"uint256\"}],\"name\":\"addVoter\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"_candidateId\",\"type\":\"uint256\"}],\"name\":\"votedEvent\",\"type\":\"event\"}],\"devdoc\":{\"methods\":{}},\"userdoc\":{\"methods\":{}}},\"settings\":{\"compilationTarget\":{\"/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/election.sol\":\"Election\"},\"evmVersion\":\"byzantium\",\"libraries\":{},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/election.sol\":{\"keccak256\":\"0x175a8bf88a9e8b4b390e68c9c3e9b15c7095a4ddfbc5cd133569aa22b7140195\",\"urls\":[\"bzzr://b0a2c16899a623fbe13bbb31fbde73bb9476ad3dd9846d3605a38f51cf90459c\"]}},\"version\":1}",
-  "bytecode": "0x608060405234801561001057600080fd5b5061005e6040805190810160405280600b81526020017f43616e64696461746520310000000000000000000000000000000000000000008152506100e2640100000000026401000000009004565b6100ab6040805190810160405280600b81526020017f43616e64696461746520320000000000000000000000000000000000000000008152506100e2640100000000026401000000009004565b6100c4606461015e640100000000026401000000009004565b6100dd60c861015e640100000000026401000000009004565b6102e8565b60026000815480929190600101919050555060606040519081016040528060025481526020018281526020016000815250600080600254815260200190815260200160002060008201518160000155602082015181600101908051906020019061014d929190610243565b506040820151816002015590505050565b60036000815480929190600101919050555060a060405190810160405280828152602001600115158152602001600015158152602001600081526020016000815250600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000820151816000015560208201518160010160006101000a81548160ff02191690831515021790555060408201518160010160016101000a81548160ff021916908315150217905550606082015181600201556080820151816003015590505050565b828054600181600116156101000203166002900490600052602060002090601f016020900481019282601f1061028457805160ff19168380011785556102b2565b828001600101855582156102b2579182015b828111156102b1578251825591602001919060010190610296565b5b5090506102bf91906102c3565b5090565b6102e591905b808211156102e15760008160009055506001016102c9565b5090565b90565b610615806102f76000396000f300608060405260043610610078576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630121b93f1461007d5780632d35a8a2146100aa5780633477ee2e146100d557806398c0793814610189578063a3ec138d146101b4578063d8f7a0bb1461022f575b600080fd5b34801561008957600080fd5b506100a86004803603810190808035906020019092919050505061025c565b005b3480156100b657600080fd5b506100bf6103e6565b6040518082815260200191505060405180910390f35b3480156100e157600080fd5b50610100600480360381019080803590602001909291905050506103ec565b6040518084815260200180602001838152602001828103825284818151815260200191508051906020019080838360005b8381101561014c578082015181840152602081019050610131565b50505050905090810190601f1680156101795780820380516001836020036101000a031916815260200191505b5094505050505060405180910390f35b34801561019557600080fd5b5061019e6104ae565b6040518082815260200191505060405180910390f35b3480156101c057600080fd5b506101f5600480360381019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506104b4565b6040518086815260200185151515158152602001841515151581526020018381526020018281526020019550505050505060405180910390f35b34801561023b57600080fd5b5061025a60048036038101908080359060200190929190505050610504565b005b60011515600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160009054906101000a900460ff1615151415156102be57600080fd5b600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160019054906101000a900460ff1615151561031a57600080fd5b60008111801561032c57506002548111155b151561033757600080fd5b60018060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160016101000a81548160ff02191690831515021790555060008082815260200190815260200160002060020160008154809291906001019190505550807ffff3c900d938d21d0990d786e819f29b8d05c1ef587b462b939609625b684b1660405160405180910390a250565b60025481565b6000602052806000526040600020600091509050806000015490806001018054600181600116156101000203166002900480601f01602080910402602001604051908101604052809291908181526020018280546001816001161561010002031660029004801561049e5780601f106104735761010080835404028352916020019161049e565b820191906000526020600020905b81548152906001019060200180831161048157829003601f168201915b5050505050908060020154905083565b60035481565b60016020528060005260406000206000915090508060000154908060010160009054906101000a900460ff16908060010160019054906101000a900460ff16908060020154908060030154905085565b60036000815480929190600101919050555060a060405190810160405280828152602001600115158152602001600015158152602001600081526020016000815250600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000820151816000015560208201518160010160006101000a81548160ff02191690831515021790555060408201518160010160016101000a81548160ff0219169083151502179055506060820151816002015560808201518160030155905050505600a165627a7a72305820839f1b2b60c267e5e5f52075160e568fd258c37cdf8f01985f30adab36fa3fb50029",
-  "deployedBytecode": "0x608060405260043610610078576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630121b93f1461007d5780632d35a8a2146100aa5780633477ee2e146100d557806398c0793814610189578063a3ec138d146101b4578063d8f7a0bb1461022f575b600080fd5b34801561008957600080fd5b506100a86004803603810190808035906020019092919050505061025c565b005b3480156100b657600080fd5b506100bf6103e6565b6040518082815260200191505060405180910390f35b3480156100e157600080fd5b50610100600480360381019080803590602001909291905050506103ec565b6040518084815260200180602001838152602001828103825284818151815260200191508051906020019080838360005b8381101561014c578082015181840152602081019050610131565b50505050905090810190601f1680156101795780820380516001836020036101000a031916815260200191505b5094505050505060405180910390f35b34801561019557600080fd5b5061019e6104ae565b6040518082815260200191505060405180910390f35b3480156101c057600080fd5b506101f5600480360381019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506104b4565b6040518086815260200185151515158152602001841515151581526020018381526020018281526020019550505050505060405180910390f35b34801561023b57600080fd5b5061025a60048036038101908080359060200190929190505050610504565b005b60011515600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160009054906101000a900460ff1615151415156102be57600080fd5b600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160019054906101000a900460ff1615151561031a57600080fd5b60008111801561032c57506002548111155b151561033757600080fd5b60018060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160016101000a81548160ff02191690831515021790555060008082815260200190815260200160002060020160008154809291906001019190505550807ffff3c900d938d21d0990d786e819f29b8d05c1ef587b462b939609625b684b1660405160405180910390a250565b60025481565b6000602052806000526040600020600091509050806000015490806001018054600181600116156101000203166002900480601f01602080910402602001604051908101604052809291908181526020018280546001816001161561010002031660029004801561049e5780601f106104735761010080835404028352916020019161049e565b820191906000526020600020905b81548152906001019060200180831161048157829003601f168201915b5050505050908060020154905083565b60035481565b60016020528060005260406000206000915090508060000154908060010160009054906101000a900460ff16908060010160019054906101000a900460ff16908060020154908060030154905085565b60036000815480929190600101919050555060a060405190810160405280828152602001600115158152602001600015158152602001600081526020016000815250600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000820151816000015560208201518160010160006101000a81548160ff02191690831515021790555060408201518160010160016101000a81548160ff0219169083151502179055506060820151816002015560808201518160030155905050505600a165627a7a72305820839f1b2b60c267e5e5f52075160e568fd258c37cdf8f01985f30adab36fa3fb50029",
-  "sourceMap": "27:2070:1:-;;;928:136;8:9:-1;5:2;;;30:1;27;20:12;5:2;928:136:1;953:27;;;;;;;;;;;;;;;;;;;:12;;;:27;;;:::i;:::-;984;;;;;;;;;;;;;;;;;;;:12;;;:27;;;:::i;:::-;1016:13;1025:3;1016:8;;;:13;;;:::i;:::-;1047;1056:3;1047:8;;;:13;;;:::i;:::-;27:2070;;1118:137;1165:15;;:17;;;;;;;;;;;;;1215:36;;;;;;;;;1225:15;;1215:36;;;;1242:5;1215:36;;;;1249:1;1215:36;;;1185:10;:27;1196:15;;1185:27;;;;;;;;;;;:66;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;1118:137;:::o;1300:186::-;1346:11;;:13;;;;;;;;;;;;;1383:33;;;;;;;;;1389:11;1383:33;;;;1401:4;1383:33;;;;;;1406:5;1383:33;;;;;;1412:1;1383:33;;;;1414:1;1383:33;;;1362:6;:18;1369:10;1362:18;;;;;;;;;;;;;;;:54;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1300:186;:::o;27:2070::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;:::o;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;:::o;:::-;;;;;;;",
-  "deployedSourceMap": "27:2070:1:-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1490:604;;8:9:-1;5:2;;;30:1;27;20:12;5:2;1490:604:1;;;;;;;;;;;;;;;;;;;;;;;;;;805:27;;8:9:-1;5:2;;;30:1;27;20:12;5:2;805:27:1;;;;;;;;;;;;;;;;;;;;;;;557:44;;8:9:-1;5:2;;;30:1;27;20:12;5:2;557:44:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;23:1:-1;8:100;33:3;30:1;27:10;8:100;;;99:1;94:3;90:11;84:18;80:1;75:3;71:11;64:39;52:2;49:1;45:10;40:15;;8:100;;;12:14;557:44:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;869:23;;8:9:-1;5:2;;;30:1;27;20:12;5:2;869:23:1;;;;;;;;;;;;;;;;;;;;;;;641:39;;8:9:-1;5:2;;;30:1;27;20:12;5:2;641:39:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1300:186;;8:9:-1;5:2;;;30:1;27;20:12;5:2;1300:186:1;;;;;;;;;;;;;;;;;;;;;;;;;;1490:604;1620:4;1586:38;;:6;:18;1593:10;1586:18;;;;;;;;;;;;;;;:30;;;;;;;;;;;;:38;;;1578:47;;;;;;;;1698:6;:18;1705:10;1698:18;;;;;;;;;;;;;;;:27;;;;;;;;;;;;1697:28;1689:37;;;;;;;;1800:1;1785:12;:16;:51;;;;;1821:15;;1805:12;:31;;1785:51;1777:60;;;;;;;;1920:4;1890:6;:18;1897:10;1890:18;;;;;;;;;;;;;;;:27;;;:34;;;;;;;;;;;;;;;;;;1977:10;:24;1988:12;1977:24;;;;;;;;;;;:34;;;:36;;;;;;;;;;;;;2073:12;2062:24;;;;;;;;;;1490:604;:::o;805:27::-;;;;:::o;557:44::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::o;869:23::-;;;;:::o;641:39::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::o;1300:186::-;1346:11;;:13;;;;;;;;;;;;;1383:33;;;;;;;;;1389:11;1383:33;;;;1401:4;1383:33;;;;;;1406:5;1383:33;;;;;;1412:1;1383:33;;;;1414:1;1383:33;;;1362:6;:18;1369:10;1362:18;;;;;;;;;;;;;;;:54;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1300:186;:::o",
-  "source": "pragma solidity ^0.4.2;\r\n\r\ncontract Election {\r\n// Model a Candidate\r\n struct Candidate {\r\n\tuint id;\r\n\tstring name;\r\n\tuint voteCount;\r\n}\r\n//Modle a voter\r\nstruct Voter {\r\n  uint NID;     // govt issued national identification number of candidate\r\n  bool eligibility;      // stores the valid list of voters during registration\r\n  bool hasVoted;    // updates when vote is successfully casted on blockchain\r\n  uint blindedVote;    // stores each voter's hashed vote\r\n  uint signedBlindedVote;  // blind signature of casted vote\r\n}\r\n// Read/write candidates\r\nmapping(uint => Candidate) public candidates;\r\n\r\n// Store accounts that have voted\r\nmapping(address => Voter) public voters;\r\n\r\n// event for logging successful votes\r\nevent votedEvent(\r\n  uint indexed _candidateId\r\n  );\r\n// Store Candidates Count\r\nuint public candidatesCount;   // counter cache for candidates\r\nuint public votersCount;    // counter cache for voters\r\n\r\nconstructor() public {\r\n\taddCandidate(\"Candidate 1\");\r\n\taddCandidate(\"Candidate 2\");\r\n  addVoter(100);  // Null NID\r\n  addVoter(200);\r\n}\r\n\r\n// candidates are pre populated for the election\r\nfunction addCandidate(string _name) private {\r\ncandidatesCount++;\r\ncandidates[candidatesCount] = Candidate(candidatesCount, _name, 0);\r\n}\r\n\r\n// anyone can register for the election\r\nfunction addVoter(uint _nationalID) public {\r\nvotersCount++;\r\nvoters[msg.sender] = Voter(_nationalID,true,false,0,0);   // (NID, eligibility, hasVoted, BlindedVote, signedBlindedVote)\r\n}\r\n\r\nfunction vote(uint _candidateId) public {\r\n\r\n        // registered voter check\r\n        require(voters[msg.sender].eligibility == true);\r\n\r\n        // require that they haven't voted before\r\n        require(!voters[msg.sender].hasVoted);\r\n\r\n        // require a valid candidate\r\n        require(_candidateId > 0 && _candidateId <= candidatesCount);\r\n\r\n        // record that voter has voted\r\n        voters[msg.sender].hasVoted = true;\r\n\r\n        // update candidate vote Count\r\n        candidates[_candidateId].voteCount++;\r\n\r\n        //trigger voted event\r\n        emit votedEvent(_candidateId);\r\n    }\r\n}\r\n",
+  "metadata": "{\"compiler\":{\"version\":\"0.4.23+commit.124ca40d\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"constant\":false,\"inputs\":[{\"name\":\"_candidateId\",\"type\":\"uint256\"}],\"name\":\"vote\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"candidatesCount\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"candidates\",\"outputs\":[{\"name\":\"id\",\"type\":\"uint256\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"voteCount\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"votersCount\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"address\"}],\"name\":\"voters\",\"outputs\":[{\"name\":\"NID\",\"type\":\"uint256\"},{\"name\":\"eligibility\",\"type\":\"bool\"},{\"name\":\"hasVoted\",\"type\":\"bool\"},{\"name\":\"blindedVote\",\"type\":\"uint256\"},{\"name\":\"signedBlindedVote\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_nationalID\",\"type\":\"uint256\"}],\"name\":\"addVoter\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"_candidateId\",\"type\":\"uint256\"}],\"name\":\"votedEvent\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"_nationalID\",\"type\":\"uint256\"}],\"name\":\"newVoter\",\"type\":\"event\"}],\"devdoc\":{\"methods\":{}},\"userdoc\":{\"methods\":{}}},\"settings\":{\"compilationTarget\":{\"/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/election.sol\":\"Election\"},\"evmVersion\":\"byzantium\",\"libraries\":{},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/election.sol\":{\"keccak256\":\"0x6e4b1d0b80229447425a479cf4cfd5ad97d286da79bed256fbc4d5cc2c5cabb1\",\"urls\":[\"bzzr://7110cccbebb33c935e7402b9eb774fc715d48378ce0fb751f65b538ab8069533\"]}},\"version\":1}",
+  "bytecode": "0x608060405234801561001057600080fd5b5061005e6040805190810160405280600b81526020017f43616e64696461746520310000000000000000000000000000000000000000008152506100b0640100000000026401000000009004565b6100ab6040805190810160405280600b81526020017f43616e64696461746520320000000000000000000000000000000000000000008152506100b0640100000000026401000000009004565b6101d1565b60026000815480929190600101919050555060606040519081016040528060025481526020018281526020016000815250600080600254815260200190815260200160002060008201518160000155602082015181600101908051906020019061011b92919061012c565b506040820151816002015590505050565b828054600181600116156101000203166002900490600052602060002090601f016020900481019282601f1061016d57805160ff191683800117855561019b565b8280016001018555821561019b579182015b8281111561019a57825182559160200191906001019061017f565b5b5090506101a891906101ac565b5090565b6101ce91905b808211156101ca5760008160009055506001016101b2565b5090565b90565b6106f2806101e06000396000f300608060405260043610610078576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630121b93f1461007d5780632d35a8a2146100aa5780633477ee2e146100d557806398c0793814610189578063a3ec138d146101b4578063d8f7a0bb1461022f575b600080fd5b34801561008957600080fd5b506100a86004803603810190808035906020019092919050505061025c565b005b3480156100b657600080fd5b506100bf6103e6565b6040518082815260200191505060405180910390f35b3480156100e157600080fd5b50610100600480360381019080803590602001909291905050506103ec565b6040518084815260200180602001838152602001828103825284818151815260200191508051906020019080838360005b8381101561014c578082015181840152602081019050610131565b50505050905090810190601f1680156101795780820380516001836020036101000a031916815260200191505b5094505050505060405180910390f35b34801561019557600080fd5b5061019e6104ae565b6040518082815260200191505060405180910390f35b3480156101c057600080fd5b506101f5600480360381019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506104b4565b6040518086815260200185151515158152602001841515151581526020018381526020018281526020019550505050505060405180910390f35b34801561023b57600080fd5b5061025a60048036038101908080359060200190929190505050610504565b005b60011515600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160009054906101000a900460ff1615151415156102be57600080fd5b600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160019054906101000a900460ff1615151561031a57600080fd5b60008111801561032c57506002548111155b151561033757600080fd5b60018060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160016101000a81548160ff02191690831515021790555060008082815260200190815260200160002060020160008154809291906001019190505550807ffff3c900d938d21d0990d786e819f29b8d05c1ef587b462b939609625b684b1660405160405180910390a250565b60025481565b6000602052806000526040600020600091509050806000015490806001018054600181600116156101000203166002900480601f01602080910402602001604051908101604052809291908181526020018280546001816001161561010002031660029004801561049e5780601f106104735761010080835404028352916020019161049e565b820191906000526020600020905b81548152906001019060200180831161048157829003601f168201915b5050505050908060020154905083565b60035481565b60016020528060005260406000206000915090508060000154908060010160009054906101000a900460ff16908060010160019054906101000a900460ff16908060020154908060030154905085565b60001515600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160009054906101000a900460ff1615151480156105a9575080600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000015414155b15156105b457600080fd5b60036000815480929190600101919050555060a060405190810160405280828152602001600115158152602001600015158152602001600081526020016000815250600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000820151816000015560208201518160010160006101000a81548160ff02191690831515021790555060408201518160010160016101000a81548160ff0219169083151502179055506060820151816002015560808201518160030155905050807fdf46bb731dd3f934fde468a9d86e0ccf9197f737d59f9df5e4d75f380a44e2d960405160405180910390a2505600a165627a7a72305820ddee80aad71be8e311aac956f622f06e898360d5ec255b579199462c1e483adf0029",
+  "deployedBytecode": "0x608060405260043610610078576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630121b93f1461007d5780632d35a8a2146100aa5780633477ee2e146100d557806398c0793814610189578063a3ec138d146101b4578063d8f7a0bb1461022f575b600080fd5b34801561008957600080fd5b506100a86004803603810190808035906020019092919050505061025c565b005b3480156100b657600080fd5b506100bf6103e6565b6040518082815260200191505060405180910390f35b3480156100e157600080fd5b50610100600480360381019080803590602001909291905050506103ec565b6040518084815260200180602001838152602001828103825284818151815260200191508051906020019080838360005b8381101561014c578082015181840152602081019050610131565b50505050905090810190601f1680156101795780820380516001836020036101000a031916815260200191505b5094505050505060405180910390f35b34801561019557600080fd5b5061019e6104ae565b6040518082815260200191505060405180910390f35b3480156101c057600080fd5b506101f5600480360381019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506104b4565b6040518086815260200185151515158152602001841515151581526020018381526020018281526020019550505050505060405180910390f35b34801561023b57600080fd5b5061025a60048036038101908080359060200190929190505050610504565b005b60011515600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160009054906101000a900460ff1615151415156102be57600080fd5b600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160019054906101000a900460ff1615151561031a57600080fd5b60008111801561032c57506002548111155b151561033757600080fd5b60018060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160016101000a81548160ff02191690831515021790555060008082815260200190815260200160002060020160008154809291906001019190505550807ffff3c900d938d21d0990d786e819f29b8d05c1ef587b462b939609625b684b1660405160405180910390a250565b60025481565b6000602052806000526040600020600091509050806000015490806001018054600181600116156101000203166002900480601f01602080910402602001604051908101604052809291908181526020018280546001816001161561010002031660029004801561049e5780601f106104735761010080835404028352916020019161049e565b820191906000526020600020905b81548152906001019060200180831161048157829003601f168201915b5050505050908060020154905083565b60035481565b60016020528060005260406000206000915090508060000154908060010160009054906101000a900460ff16908060010160019054906101000a900460ff16908060020154908060030154905085565b60001515600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160009054906101000a900460ff1615151480156105a9575080600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000015414155b15156105b457600080fd5b60036000815480929190600101919050555060a060405190810160405280828152602001600115158152602001600015158152602001600081526020016000815250600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000820151816000015560208201518160010160006101000a81548160ff02191690831515021790555060408201518160010160016101000a81548160ff0219169083151502179055506060820151816002015560808201518160030155905050807fdf46bb731dd3f934fde468a9d86e0ccf9197f737d59f9df5e4d75f380a44e2d960405160405180910390a2505600a165627a7a72305820ddee80aad71be8e311aac956f622f06e898360d5ec255b579199462c1e483adf0029",
+  "sourceMap": "28:2919:1:-;;;1157:549;8:9:-1;5:2;;;30:1;27;20:12;5:2;1157:549:1;1185:27;;;;;;;;;;;;;;;;;;;:12;;;:27;;;:::i;:::-;1216;;;;;;;;;;;;;;;;;;;:12;;;:27;;;:::i;:::-;28:2919;;1760:137;1807:15;;:17;;;;;;;;;;;;;1857:36;;;;;;;;;1867:15;;1857:36;;;;1884:5;1857:36;;;;1891:1;1857:36;;;1827:10;:27;1838:15;;1827:27;;;;;;;;;;;:66;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;1760:137;:::o;28:2919::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;:::o;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;:::o;:::-;;;;;;;",
+  "deployedSourceMap": "28:2919:1:-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;2340:604;;8:9:-1;5:2;;;30:1;27;20:12;5:2;2340:604:1;;;;;;;;;;;;;;;;;;;;;;;;;;896:27;;8:9:-1;5:2;;;30:1;27;20:12;5:2;896:27:1;;;;;;;;;;;;;;;;;;;;;;;558:44;;8:9:-1;5:2;;;30:1;27;20:12;5:2;558:44:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;23:1:-1;8:100;33:3;30:1;27:10;8:100;;;99:1;94:3;90:11;84:18;80:1;75:3;71:11;64:39;52:2;49:1;45:10;40:15;;8:100;;;12:14;558:44:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;960:23;;8:9:-1;5:2;;;30:1;27;20:12;5:2;960:23:1;;;;;;;;;;;;;;;;;;;;;;;642:39;;8:9:-1;5:2;;;30:1;27;20:12;5:2;642:39:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1942:394;;8:9:-1;5:2;;;30:1;27;20:12;5:2;1942:394:1;;;;;;;;;;;;;;;;;;;;;;;;;;2340:604;2470:4;2436:38;;:6;:18;2443:10;2436:18;;;;;;;;;;;;;;;:30;;;;;;;;;;;;:38;;;2428:47;;;;;;;;2548:6;:18;2555:10;2548:18;;;;;;;;;;;;;;;:27;;;;;;;;;;;;2547:28;2539:37;;;;;;;;2650:1;2635:12;:16;:51;;;;;2671:15;;2655:12;:31;;2635:51;2627:60;;;;;;;;2770:4;2740:6;:18;2747:10;2740:18;;;;;;;;;;;;;;;:27;;;:34;;;;;;;;;;;;;;;;;;2827:10;:24;2838:12;2827:24;;;;;;;;;;;:34;;;:36;;;;;;;;;;;;;2923:12;2912:24;;;;;;;;;;2340:604;:::o;896:27::-;;;;:::o;558:44::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::o;960:23::-;;;;:::o;642:39::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::o;1942:394::-;2030:5;1996:39;;:6;:18;2003:10;1996:18;;;;;;;;;;;;;;;:30;;;;;;;;;;;;:39;;;:80;;;;;2065:11;2039:6;:18;2046:10;2039:18;;;;;;;;;;;;;;;:22;;;:37;;1996:80;1988:89;;;;;;;;2167:11;;:13;;;;;;;;;;;;;2204:33;;;;;;;;;2210:11;2204:33;;;;2222:4;2204:33;;;;;;2227:5;2204:33;;;;;;2233:1;2204:33;;;;2235:1;2204:33;;;2183:6;:18;2190:10;2183:18;;;;;;;;;;;;;;;:54;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;2320:11;2311:21;;;;;;;;;;1942:394;:::o",
+  "source": "pragma solidity ^0.4.23;\r\n\r\ncontract Election {\r\n// Model a Candidate\r\n struct Candidate {\r\n\tuint id;\r\n\tstring name;\r\n\tuint voteCount;\r\n}\r\n//Modle a voter\r\nstruct Voter {\r\n  uint NID;     // govt issued national identification number of candidate\r\n  bool eligibility;      // stores the valid list of voters during registration\r\n  bool hasVoted;    // updates when vote is successfully casted on blockchain\r\n  uint blindedVote;    // stores each voter's hashed vote\r\n  uint signedBlindedVote;  // blind signature of casted vote\r\n}\r\n// Read/write candidates\r\nmapping(uint => Candidate) public candidates;\r\n\r\n// Store accounts that have voted\r\nmapping(address => Voter) public voters;\r\n\r\n// event for logging successful votes\r\nevent votedEvent(\r\n  uint indexed _candidateId\r\n  );\r\n\r\n// event for logging successful votes\r\nevent newVoter(\r\n  uint indexed _nationalID\r\n);\r\n// Store Candidates Count\r\nuint public candidatesCount;   // counter cache for candidates\r\nuint public votersCount;    // counter cache for voters\r\n\r\n// DEMO Voter accounts\r\n// voter-1 : 0x793ab88bDa1029b65737D71a2402f18D15C09AC8\r\n// voter-2 : 0xD8b33BF7080dF17888690fa6092300DEd6C19fC8\r\nconstructor() public {\r\n\r\n  addCandidate(\"Candidate 1\");\r\n\taddCandidate(\"Candidate 2\");\r\n//  addVoter(100);   addvoter() function is not used in constructor statement because it invokes require(), but the contract hasn't beem created before constructor call\r\n//  addVoter(200);\r\n  /* votersCount++;\r\n  voters[0x793ab88bDa1029b65737D71a2402f18D15C09AC8] = Voter(100,true,false,0,0); // first demo voter NID - 100\r\n  votersCount++;\r\n  voters[0x793ab88bDa1029b65737D71a2402f18D15C09AC8] = Voter(200,true,false,0,0); // second demo voter NID - 200 */\r\n}\r\n\r\n// candidates are pre populated for the election\r\nfunction addCandidate(string _name) private {\r\ncandidatesCount++;\r\ncandidates[candidatesCount] = Candidate(candidatesCount, _name, 0);\r\n}\r\n\r\n// anyone can register for the election\r\nfunction addVoter(uint _nationalID) public {\r\nrequire(voters[msg.sender].eligibility == false && voters[msg.sender].NID != _nationalID);  //checks if voter has registered before with same NID / Disallows Double Registration\r\nvotersCount++;\r\nvoters[msg.sender] = Voter(_nationalID,true,false,0,0);   // (NID, eligibility, hasVoted, BlindedVote, signedBlindedVote)\r\nemit newVoter(_nationalID);\r\n}\r\n\r\nfunction vote(uint _candidateId) public {\r\n\r\n        // registered voter check\r\n        require(voters[msg.sender].eligibility == true);\r\n\r\n        // require that they haven't voted before\r\n        require(!voters[msg.sender].hasVoted);\r\n\r\n        // require a valid candidate\r\n        require(_candidateId > 0 && _candidateId <= candidatesCount);\r\n\r\n        // record that voter has voted\r\n        voters[msg.sender].hasVoted = true;\r\n\r\n        // update candidate vote Count\r\n        candidates[_candidateId].voteCount++;\r\n\r\n        //trigger voted event\r\n        emit votedEvent(_candidateId);\r\n    }\r\n}\r\n",
   "sourcePath": "L:/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/election.sol",
   "ast": {
     "absolutePath": "/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/election.sol",
     "exportedSymbols": {
       "Election": [
-        207
+        225
       ]
     },
-    "id": 208,
+    "id": 226,
     "nodeType": "SourceUnit",
     "nodes": [
       {
@@ -161,10 +173,10 @@
           "solidity",
           "^",
           "0.4",
-          ".2"
+          ".23"
         ],
         "nodeType": "PragmaDirective",
-        "src": "0:23:1"
+        "src": "0:24:1"
       },
       {
         "baseContracts": [],
@@ -172,9 +184,9 @@
         "contractKind": "contract",
         "documentation": null,
         "fullyImplemented": true,
-        "id": 207,
+        "id": 225,
         "linearizedBaseContracts": [
-          207
+          225
         ],
         "name": "Election",
         "nodeType": "ContractDefinition",
@@ -189,7 +201,7 @@
                 "name": "id",
                 "nodeType": "VariableDeclaration",
                 "scope": 65,
-                "src": "92:7:1",
+                "src": "93:7:1",
                 "stateVariable": false,
                 "storageLocation": "default",
                 "typeDescriptions": {
@@ -200,7 +212,7 @@
                   "id": 59,
                   "name": "uint",
                   "nodeType": "ElementaryTypeName",
-                  "src": "92:4:1",
+                  "src": "93:4:1",
                   "typeDescriptions": {
                     "typeIdentifier": "t_uint256",
                     "typeString": "uint256"
@@ -215,7 +227,7 @@
                 "name": "name",
                 "nodeType": "VariableDeclaration",
                 "scope": 65,
-                "src": "103:11:1",
+                "src": "104:11:1",
                 "stateVariable": false,
                 "storageLocation": "default",
                 "typeDescriptions": {
@@ -226,7 +238,7 @@
                   "id": 61,
                   "name": "string",
                   "nodeType": "ElementaryTypeName",
-                  "src": "103:6:1",
+                  "src": "104:6:1",
                   "typeDescriptions": {
                     "typeIdentifier": "t_string_storage_ptr",
                     "typeString": "string"
@@ -241,7 +253,7 @@
                 "name": "voteCount",
                 "nodeType": "VariableDeclaration",
                 "scope": 65,
-                "src": "118:14:1",
+                "src": "119:14:1",
                 "stateVariable": false,
                 "storageLocation": "default",
                 "typeDescriptions": {
@@ -252,7 +264,7 @@
                   "id": 63,
                   "name": "uint",
                   "nodeType": "ElementaryTypeName",
-                  "src": "118:4:1",
+                  "src": "119:4:1",
                   "typeDescriptions": {
                     "typeIdentifier": "t_uint256",
                     "typeString": "uint256"
@@ -264,8 +276,8 @@
             ],
             "name": "Candidate",
             "nodeType": "StructDefinition",
-            "scope": 207,
-            "src": "71:65:1",
+            "scope": 225,
+            "src": "72:65:1",
             "visibility": "public"
           },
           {
@@ -278,7 +290,7 @@
                 "name": "NID",
                 "nodeType": "VariableDeclaration",
                 "scope": 76,
-                "src": "173:8:1",
+                "src": "174:8:1",
                 "stateVariable": false,
                 "storageLocation": "default",
                 "typeDescriptions": {
@@ -289,7 +301,7 @@
                   "id": 66,
                   "name": "uint",
                   "nodeType": "ElementaryTypeName",
-                  "src": "173:4:1",
+                  "src": "174:4:1",
                   "typeDescriptions": {
                     "typeIdentifier": "t_uint256",
                     "typeString": "uint256"
@@ -304,7 +316,7 @@
                 "name": "eligibility",
                 "nodeType": "VariableDeclaration",
                 "scope": 76,
-                "src": "249:16:1",
+                "src": "250:16:1",
                 "stateVariable": false,
                 "storageLocation": "default",
                 "typeDescriptions": {
@@ -315,7 +327,7 @@
                   "id": 68,
                   "name": "bool",
                   "nodeType": "ElementaryTypeName",
-                  "src": "249:4:1",
+                  "src": "250:4:1",
                   "typeDescriptions": {
                     "typeIdentifier": "t_bool",
                     "typeString": "bool"
@@ -330,7 +342,7 @@
                 "name": "hasVoted",
                 "nodeType": "VariableDeclaration",
                 "scope": 76,
-                "src": "330:13:1",
+                "src": "331:13:1",
                 "stateVariable": false,
                 "storageLocation": "default",
                 "typeDescriptions": {
@@ -341,7 +353,7 @@
                   "id": 70,
                   "name": "bool",
                   "nodeType": "ElementaryTypeName",
-                  "src": "330:4:1",
+                  "src": "331:4:1",
                   "typeDescriptions": {
                     "typeIdentifier": "t_bool",
                     "typeString": "bool"
@@ -356,7 +368,7 @@
                 "name": "blindedVote",
                 "nodeType": "VariableDeclaration",
                 "scope": 76,
-                "src": "409:16:1",
+                "src": "410:16:1",
                 "stateVariable": false,
                 "storageLocation": "default",
                 "typeDescriptions": {
@@ -367,7 +379,7 @@
                   "id": 72,
                   "name": "uint",
                   "nodeType": "ElementaryTypeName",
-                  "src": "409:4:1",
+                  "src": "410:4:1",
                   "typeDescriptions": {
                     "typeIdentifier": "t_uint256",
                     "typeString": "uint256"
@@ -382,7 +394,7 @@
                 "name": "signedBlindedVote",
                 "nodeType": "VariableDeclaration",
                 "scope": 76,
-                "src": "468:22:1",
+                "src": "469:22:1",
                 "stateVariable": false,
                 "storageLocation": "default",
                 "typeDescriptions": {
@@ -393,7 +405,7 @@
                   "id": 74,
                   "name": "uint",
                   "nodeType": "ElementaryTypeName",
-                  "src": "468:4:1",
+                  "src": "469:4:1",
                   "typeDescriptions": {
                     "typeIdentifier": "t_uint256",
                     "typeString": "uint256"
@@ -405,8 +417,8 @@
             ],
             "name": "Voter",
             "nodeType": "StructDefinition",
-            "scope": 207,
-            "src": "155:374:1",
+            "scope": 225,
+            "src": "156:374:1",
             "visibility": "public"
           },
           {
@@ -414,8 +426,8 @@
             "id": 80,
             "name": "candidates",
             "nodeType": "VariableDeclaration",
-            "scope": 207,
-            "src": "557:44:1",
+            "scope": 225,
+            "src": "558:44:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -428,14 +440,14 @@
                 "id": 77,
                 "name": "uint",
                 "nodeType": "ElementaryTypeName",
-                "src": "565:4:1",
+                "src": "566:4:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_uint256",
                   "typeString": "uint256"
                 }
               },
               "nodeType": "Mapping",
-              "src": "557:26:1",
+              "src": "558:26:1",
               "typeDescriptions": {
                 "typeIdentifier": "t_mapping$_t_uint256_$_t_struct$_Candidate_$65_storage_$",
                 "typeString": "mapping(uint256 => struct Election.Candidate)"
@@ -446,7 +458,7 @@
                 "name": "Candidate",
                 "nodeType": "UserDefinedTypeName",
                 "referencedDeclaration": 65,
-                "src": "573:9:1",
+                "src": "574:9:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_struct$_Candidate_$65_storage_ptr",
                   "typeString": "struct Election.Candidate"
@@ -461,8 +473,8 @@
             "id": 84,
             "name": "voters",
             "nodeType": "VariableDeclaration",
-            "scope": 207,
-            "src": "641:39:1",
+            "scope": 225,
+            "src": "642:39:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -475,14 +487,14 @@
                 "id": 81,
                 "name": "address",
                 "nodeType": "ElementaryTypeName",
-                "src": "649:7:1",
+                "src": "650:7:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_address",
                   "typeString": "address"
                 }
               },
               "nodeType": "Mapping",
-              "src": "641:25:1",
+              "src": "642:25:1",
               "typeDescriptions": {
                 "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
                 "typeString": "mapping(address => struct Election.Voter)"
@@ -493,7 +505,7 @@
                 "name": "Voter",
                 "nodeType": "UserDefinedTypeName",
                 "referencedDeclaration": 76,
-                "src": "660:5:1",
+                "src": "661:5:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_struct$_Voter_$76_storage_ptr",
                   "typeString": "struct Election.Voter"
@@ -520,7 +532,7 @@
                   "name": "_candidateId",
                   "nodeType": "VariableDeclaration",
                   "scope": 88,
-                  "src": "745:25:1",
+                  "src": "746:25:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -531,7 +543,7 @@
                     "id": 85,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
-                    "src": "745:4:1",
+                    "src": "746:4:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -541,17 +553,59 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "740:35:1"
+              "src": "741:35:1"
             },
-            "src": "724:52:1"
+            "src": "725:52:1"
+          },
+          {
+            "anonymous": false,
+            "documentation": null,
+            "id": 92,
+            "name": "newVoter",
+            "nodeType": "EventDefinition",
+            "parameters": {
+              "id": 91,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 90,
+                  "indexed": true,
+                  "name": "_nationalID",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 92,
+                  "src": "839:24:1",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 89,
+                    "name": "uint",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "839:4:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                }
+              ],
+              "src": "834:32:1"
+            },
+            "src": "820:47:1"
           },
           {
             "constant": false,
-            "id": 90,
+            "id": 94,
             "name": "candidatesCount",
             "nodeType": "VariableDeclaration",
-            "scope": 207,
-            "src": "805:27:1",
+            "scope": 225,
+            "src": "896:27:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -559,10 +613,10 @@
               "typeString": "uint256"
             },
             "typeName": {
-              "id": 89,
+              "id": 93,
               "name": "uint",
               "nodeType": "ElementaryTypeName",
-              "src": "805:4:1",
+              "src": "896:4:1",
               "typeDescriptions": {
                 "typeIdentifier": "t_uint256",
                 "typeString": "uint256"
@@ -573,11 +627,11 @@
           },
           {
             "constant": false,
-            "id": 92,
+            "id": 96,
             "name": "votersCount",
             "nodeType": "VariableDeclaration",
-            "scope": 207,
-            "src": "869:23:1",
+            "scope": 225,
+            "src": "960:23:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -585,10 +639,10 @@
               "typeString": "uint256"
             },
             "typeName": {
-              "id": 91,
+              "id": 95,
               "name": "uint",
               "nodeType": "ElementaryTypeName",
-              "src": "869:4:1",
+              "src": "960:4:1",
               "typeDescriptions": {
                 "typeIdentifier": "t_uint256",
                 "typeString": "uint256"
@@ -599,9 +653,9 @@
           },
           {
             "body": {
-              "id": 111,
+              "id": 107,
               "nodeType": "Block",
-              "src": "949:115:1",
+              "src": "1178:528:1",
               "statements": [
                 {
                   "expression": {
@@ -610,14 +664,14 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "43616e6469646174652031",
-                        "id": 96,
+                        "id": 100,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
                         "kind": "string",
                         "lValueRequested": false,
                         "nodeType": "Literal",
-                        "src": "966:13:1",
+                        "src": "1198:13:1",
                         "subdenomination": null,
                         "typeDescriptions": {
                           "typeIdentifier": "t_stringliteral_41f9dcbd43e9b33194759b5a51b1df9864cdc2b2138ff106f03091eb79861f0c",
@@ -633,18 +687,18 @@
                           "typeString": "literal_string \"Candidate 1\""
                         }
                       ],
-                      "id": 95,
+                      "id": 99,
                       "name": "addCandidate",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 131,
-                      "src": "953:12:1",
+                      "referencedDeclaration": 127,
+                      "src": "1185:12:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_nonpayable$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (string memory)"
                       }
                     },
-                    "id": 97,
+                    "id": 101,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -652,15 +706,15 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "953:27:1",
+                    "src": "1185:27:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 98,
+                  "id": 102,
                   "nodeType": "ExpressionStatement",
-                  "src": "953:27:1"
+                  "src": "1185:27:1"
                 },
                 {
                   "expression": {
@@ -669,14 +723,14 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "43616e6469646174652032",
-                        "id": 100,
+                        "id": 104,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
                         "kind": "string",
                         "lValueRequested": false,
                         "nodeType": "Literal",
-                        "src": "997:13:1",
+                        "src": "1229:13:1",
                         "subdenomination": null,
                         "typeDescriptions": {
                           "typeIdentifier": "t_stringliteral_f1f17440f69835dafba5c9fd0e4caa6c780807a80f8d1745ec7af1408d6cca4a",
@@ -692,74 +746,15 @@
                           "typeString": "literal_string \"Candidate 2\""
                         }
                       ],
-                      "id": 99,
+                      "id": 103,
                       "name": "addCandidate",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 131,
-                      "src": "984:12:1",
+                      "referencedDeclaration": 127,
+                      "src": "1216:12:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_nonpayable$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (string memory)"
-                      }
-                    },
-                    "id": 101,
-                    "isConstant": false,
-                    "isLValue": false,
-                    "isPure": false,
-                    "kind": "functionCall",
-                    "lValueRequested": false,
-                    "names": [],
-                    "nodeType": "FunctionCall",
-                    "src": "984:27:1",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_tuple$__$",
-                      "typeString": "tuple()"
-                    }
-                  },
-                  "id": 102,
-                  "nodeType": "ExpressionStatement",
-                  "src": "984:27:1"
-                },
-                {
-                  "expression": {
-                    "argumentTypes": null,
-                    "arguments": [
-                      {
-                        "argumentTypes": null,
-                        "hexValue": "313030",
-                        "id": 104,
-                        "isConstant": false,
-                        "isLValue": false,
-                        "isPure": true,
-                        "kind": "number",
-                        "lValueRequested": false,
-                        "nodeType": "Literal",
-                        "src": "1025:3:1",
-                        "subdenomination": null,
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_rational_100_by_1",
-                          "typeString": "int_const 100"
-                        },
-                        "value": "100"
-                      }
-                    ],
-                    "expression": {
-                      "argumentTypes": [
-                        {
-                          "typeIdentifier": "t_rational_100_by_1",
-                          "typeString": "int_const 100"
-                        }
-                      ],
-                      "id": 103,
-                      "name": "addVoter",
-                      "nodeType": "Identifier",
-                      "overloadedDeclarations": [],
-                      "referencedDeclaration": 153,
-                      "src": "1016:8:1",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_function_internal_nonpayable$_t_uint256_$returns$__$",
-                        "typeString": "function (uint256)"
                       }
                     },
                     "id": 105,
@@ -770,7 +765,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1016:13:1",
+                    "src": "1216:27:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
@@ -778,71 +773,12 @@
                   },
                   "id": 106,
                   "nodeType": "ExpressionStatement",
-                  "src": "1016:13:1"
-                },
-                {
-                  "expression": {
-                    "argumentTypes": null,
-                    "arguments": [
-                      {
-                        "argumentTypes": null,
-                        "hexValue": "323030",
-                        "id": 108,
-                        "isConstant": false,
-                        "isLValue": false,
-                        "isPure": true,
-                        "kind": "number",
-                        "lValueRequested": false,
-                        "nodeType": "Literal",
-                        "src": "1056:3:1",
-                        "subdenomination": null,
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_rational_200_by_1",
-                          "typeString": "int_const 200"
-                        },
-                        "value": "200"
-                      }
-                    ],
-                    "expression": {
-                      "argumentTypes": [
-                        {
-                          "typeIdentifier": "t_rational_200_by_1",
-                          "typeString": "int_const 200"
-                        }
-                      ],
-                      "id": 107,
-                      "name": "addVoter",
-                      "nodeType": "Identifier",
-                      "overloadedDeclarations": [],
-                      "referencedDeclaration": 153,
-                      "src": "1047:8:1",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_function_internal_nonpayable$_t_uint256_$returns$__$",
-                        "typeString": "function (uint256)"
-                      }
-                    },
-                    "id": 109,
-                    "isConstant": false,
-                    "isLValue": false,
-                    "isPure": false,
-                    "kind": "functionCall",
-                    "lValueRequested": false,
-                    "names": [],
-                    "nodeType": "FunctionCall",
-                    "src": "1047:13:1",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_tuple$__$",
-                      "typeString": "tuple()"
-                    }
-                  },
-                  "id": 110,
-                  "nodeType": "ExpressionStatement",
-                  "src": "1047:13:1"
+                  "src": "1216:27:1"
                 }
               ]
             },
             "documentation": null,
-            "id": 112,
+            "id": 108,
             "implemented": true,
             "isConstructor": true,
             "isDeclaredConst": false,
@@ -850,34 +786,34 @@
             "name": "",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 93,
+              "id": 97,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "939:2:1"
+              "src": "1168:2:1"
             },
             "payable": false,
             "returnParameters": {
-              "id": 94,
+              "id": 98,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "949:0:1"
+              "src": "1178:0:1"
             },
-            "scope": 207,
-            "src": "928:136:1",
+            "scope": 225,
+            "src": "1157:549:1",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
           },
           {
             "body": {
-              "id": 130,
+              "id": 126,
               "nodeType": "Block",
-              "src": "1162:93:1",
+              "src": "1804:93:1",
               "statements": [
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 118,
+                    "id": 114,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -885,15 +821,15 @@
                     "nodeType": "UnaryOperation",
                     "operator": "++",
                     "prefix": false,
-                    "src": "1165:17:1",
+                    "src": "1807:17:1",
                     "subExpression": {
                       "argumentTypes": null,
-                      "id": 117,
+                      "id": 113,
                       "name": "candidatesCount",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 90,
-                      "src": "1165:15:1",
+                      "referencedDeclaration": 94,
+                      "src": "1807:15:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
@@ -904,14 +840,14 @@
                       "typeString": "uint256"
                     }
                   },
-                  "id": 119,
+                  "id": 115,
                   "nodeType": "ExpressionStatement",
-                  "src": "1165:17:1"
+                  "src": "1807:17:1"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 128,
+                    "id": 124,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -920,26 +856,26 @@
                       "argumentTypes": null,
                       "baseExpression": {
                         "argumentTypes": null,
-                        "id": 120,
+                        "id": 116,
                         "name": "candidates",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 80,
-                        "src": "1185:10:1",
+                        "src": "1827:10:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_uint256_$_t_struct$_Candidate_$65_storage_$",
                           "typeString": "mapping(uint256 => struct Election.Candidate storage ref)"
                         }
                       },
-                      "id": 122,
+                      "id": 118,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 121,
+                        "id": 117,
                         "name": "candidatesCount",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 90,
-                        "src": "1196:15:1",
+                        "referencedDeclaration": 94,
+                        "src": "1838:15:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
@@ -950,7 +886,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "1185:27:1",
+                      "src": "1827:27:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_struct$_Candidate_$65_storage",
                         "typeString": "struct Election.Candidate storage ref"
@@ -963,12 +899,12 @@
                       "arguments": [
                         {
                           "argumentTypes": null,
-                          "id": 124,
+                          "id": 120,
                           "name": "candidatesCount",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 90,
-                          "src": "1225:15:1",
+                          "referencedDeclaration": 94,
+                          "src": "1867:15:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
@@ -976,12 +912,12 @@
                         },
                         {
                           "argumentTypes": null,
-                          "id": 125,
+                          "id": 121,
                           "name": "_name",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 114,
-                          "src": "1242:5:1",
+                          "referencedDeclaration": 110,
+                          "src": "1884:5:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_string_memory_ptr",
                             "typeString": "string memory"
@@ -990,14 +926,14 @@
                         {
                           "argumentTypes": null,
                           "hexValue": "30",
-                          "id": 126,
+                          "id": 122,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
                           "kind": "number",
                           "lValueRequested": false,
                           "nodeType": "Literal",
-                          "src": "1249:1:1",
+                          "src": "1891:1:1",
                           "subdenomination": null,
                           "typeDescriptions": {
                             "typeIdentifier": "t_rational_0_by_1",
@@ -1021,18 +957,18 @@
                             "typeString": "int_const 0"
                           }
                         ],
-                        "id": 123,
+                        "id": 119,
                         "name": "Candidate",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 65,
-                        "src": "1215:9:1",
+                        "src": "1857:9:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_type$_t_struct$_Candidate_$65_storage_ptr_$",
                           "typeString": "type(struct Election.Candidate storage pointer)"
                         }
                       },
-                      "id": 127,
+                      "id": 123,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
@@ -1040,26 +976,26 @@
                       "lValueRequested": false,
                       "names": [],
                       "nodeType": "FunctionCall",
-                      "src": "1215:36:1",
+                      "src": "1857:36:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_struct$_Candidate_$65_memory",
                         "typeString": "struct Election.Candidate memory"
                       }
                     },
-                    "src": "1185:66:1",
+                    "src": "1827:66:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_struct$_Candidate_$65_storage",
                       "typeString": "struct Election.Candidate storage ref"
                     }
                   },
-                  "id": 129,
+                  "id": 125,
                   "nodeType": "ExpressionStatement",
-                  "src": "1185:66:1"
+                  "src": "1827:66:1"
                 }
               ]
             },
             "documentation": null,
-            "id": 131,
+            "id": 127,
             "implemented": true,
             "isConstructor": false,
             "isDeclaredConst": false,
@@ -1067,16 +1003,16 @@
             "name": "addCandidate",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 115,
+              "id": 111,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 114,
+                  "id": 110,
                   "name": "_name",
                   "nodeType": "VariableDeclaration",
-                  "scope": 131,
-                  "src": "1140:12:1",
+                  "scope": 127,
+                  "src": "1782:12:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1084,10 +1020,10 @@
                     "typeString": "string"
                   },
                   "typeName": {
-                    "id": 113,
+                    "id": 109,
                     "name": "string",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1140:6:1",
+                    "src": "1782:6:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_string_storage_ptr",
                       "typeString": "string"
@@ -1097,335 +1033,26 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "1139:14:1"
+              "src": "1781:14:1"
             },
             "payable": false,
             "returnParameters": {
-              "id": 116,
+              "id": 112,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "1162:0:1"
+              "src": "1804:0:1"
             },
-            "scope": 207,
-            "src": "1118:137:1",
+            "scope": 225,
+            "src": "1760:137:1",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "private"
           },
           {
             "body": {
-              "id": 152,
+              "id": 170,
               "nodeType": "Block",
-              "src": "1343:143:1",
-              "statements": [
-                {
-                  "expression": {
-                    "argumentTypes": null,
-                    "id": 137,
-                    "isConstant": false,
-                    "isLValue": false,
-                    "isPure": false,
-                    "lValueRequested": false,
-                    "nodeType": "UnaryOperation",
-                    "operator": "++",
-                    "prefix": false,
-                    "src": "1346:13:1",
-                    "subExpression": {
-                      "argumentTypes": null,
-                      "id": 136,
-                      "name": "votersCount",
-                      "nodeType": "Identifier",
-                      "overloadedDeclarations": [],
-                      "referencedDeclaration": 92,
-                      "src": "1346:11:1",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_uint256",
-                        "typeString": "uint256"
-                      }
-                    },
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "id": 138,
-                  "nodeType": "ExpressionStatement",
-                  "src": "1346:13:1"
-                },
-                {
-                  "expression": {
-                    "argumentTypes": null,
-                    "id": 150,
-                    "isConstant": false,
-                    "isLValue": false,
-                    "isPure": false,
-                    "lValueRequested": false,
-                    "leftHandSide": {
-                      "argumentTypes": null,
-                      "baseExpression": {
-                        "argumentTypes": null,
-                        "id": 139,
-                        "name": "voters",
-                        "nodeType": "Identifier",
-                        "overloadedDeclarations": [],
-                        "referencedDeclaration": 84,
-                        "src": "1362:6:1",
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
-                          "typeString": "mapping(address => struct Election.Voter storage ref)"
-                        }
-                      },
-                      "id": 142,
-                      "indexExpression": {
-                        "argumentTypes": null,
-                        "expression": {
-                          "argumentTypes": null,
-                          "id": 140,
-                          "name": "msg",
-                          "nodeType": "Identifier",
-                          "overloadedDeclarations": [],
-                          "referencedDeclaration": 222,
-                          "src": "1369:3:1",
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_magic_message",
-                            "typeString": "msg"
-                          }
-                        },
-                        "id": 141,
-                        "isConstant": false,
-                        "isLValue": false,
-                        "isPure": false,
-                        "lValueRequested": false,
-                        "memberName": "sender",
-                        "nodeType": "MemberAccess",
-                        "referencedDeclaration": null,
-                        "src": "1369:10:1",
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_address",
-                          "typeString": "address"
-                        }
-                      },
-                      "isConstant": false,
-                      "isLValue": true,
-                      "isPure": false,
-                      "lValueRequested": true,
-                      "nodeType": "IndexAccess",
-                      "src": "1362:18:1",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_struct$_Voter_$76_storage",
-                        "typeString": "struct Election.Voter storage ref"
-                      }
-                    },
-                    "nodeType": "Assignment",
-                    "operator": "=",
-                    "rightHandSide": {
-                      "argumentTypes": null,
-                      "arguments": [
-                        {
-                          "argumentTypes": null,
-                          "id": 144,
-                          "name": "_nationalID",
-                          "nodeType": "Identifier",
-                          "overloadedDeclarations": [],
-                          "referencedDeclaration": 133,
-                          "src": "1389:11:1",
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_uint256",
-                            "typeString": "uint256"
-                          }
-                        },
-                        {
-                          "argumentTypes": null,
-                          "hexValue": "74727565",
-                          "id": 145,
-                          "isConstant": false,
-                          "isLValue": false,
-                          "isPure": true,
-                          "kind": "bool",
-                          "lValueRequested": false,
-                          "nodeType": "Literal",
-                          "src": "1401:4:1",
-                          "subdenomination": null,
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_bool",
-                            "typeString": "bool"
-                          },
-                          "value": "true"
-                        },
-                        {
-                          "argumentTypes": null,
-                          "hexValue": "66616c7365",
-                          "id": 146,
-                          "isConstant": false,
-                          "isLValue": false,
-                          "isPure": true,
-                          "kind": "bool",
-                          "lValueRequested": false,
-                          "nodeType": "Literal",
-                          "src": "1406:5:1",
-                          "subdenomination": null,
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_bool",
-                            "typeString": "bool"
-                          },
-                          "value": "false"
-                        },
-                        {
-                          "argumentTypes": null,
-                          "hexValue": "30",
-                          "id": 147,
-                          "isConstant": false,
-                          "isLValue": false,
-                          "isPure": true,
-                          "kind": "number",
-                          "lValueRequested": false,
-                          "nodeType": "Literal",
-                          "src": "1412:1:1",
-                          "subdenomination": null,
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_rational_0_by_1",
-                            "typeString": "int_const 0"
-                          },
-                          "value": "0"
-                        },
-                        {
-                          "argumentTypes": null,
-                          "hexValue": "30",
-                          "id": 148,
-                          "isConstant": false,
-                          "isLValue": false,
-                          "isPure": true,
-                          "kind": "number",
-                          "lValueRequested": false,
-                          "nodeType": "Literal",
-                          "src": "1414:1:1",
-                          "subdenomination": null,
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_rational_0_by_1",
-                            "typeString": "int_const 0"
-                          },
-                          "value": "0"
-                        }
-                      ],
-                      "expression": {
-                        "argumentTypes": [
-                          {
-                            "typeIdentifier": "t_uint256",
-                            "typeString": "uint256"
-                          },
-                          {
-                            "typeIdentifier": "t_bool",
-                            "typeString": "bool"
-                          },
-                          {
-                            "typeIdentifier": "t_bool",
-                            "typeString": "bool"
-                          },
-                          {
-                            "typeIdentifier": "t_rational_0_by_1",
-                            "typeString": "int_const 0"
-                          },
-                          {
-                            "typeIdentifier": "t_rational_0_by_1",
-                            "typeString": "int_const 0"
-                          }
-                        ],
-                        "id": 143,
-                        "name": "Voter",
-                        "nodeType": "Identifier",
-                        "overloadedDeclarations": [],
-                        "referencedDeclaration": 76,
-                        "src": "1383:5:1",
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_type$_t_struct$_Voter_$76_storage_ptr_$",
-                          "typeString": "type(struct Election.Voter storage pointer)"
-                        }
-                      },
-                      "id": 149,
-                      "isConstant": false,
-                      "isLValue": false,
-                      "isPure": false,
-                      "kind": "structConstructorCall",
-                      "lValueRequested": false,
-                      "names": [],
-                      "nodeType": "FunctionCall",
-                      "src": "1383:33:1",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_struct$_Voter_$76_memory",
-                        "typeString": "struct Election.Voter memory"
-                      }
-                    },
-                    "src": "1362:54:1",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_struct$_Voter_$76_storage",
-                      "typeString": "struct Election.Voter storage ref"
-                    }
-                  },
-                  "id": 151,
-                  "nodeType": "ExpressionStatement",
-                  "src": "1362:54:1"
-                }
-              ]
-            },
-            "documentation": null,
-            "id": 153,
-            "implemented": true,
-            "isConstructor": false,
-            "isDeclaredConst": false,
-            "modifiers": [],
-            "name": "addVoter",
-            "nodeType": "FunctionDefinition",
-            "parameters": {
-              "id": 134,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 133,
-                  "name": "_nationalID",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 153,
-                  "src": "1318:16:1",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 132,
-                    "name": "uint",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1318:4:1",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "value": null,
-                  "visibility": "internal"
-                }
-              ],
-              "src": "1317:18:1"
-            },
-            "payable": false,
-            "returnParameters": {
-              "id": 135,
-              "nodeType": "ParameterList",
-              "parameters": [],
-              "src": "1343:0:1"
-            },
-            "scope": 207,
-            "src": "1300:186:1",
-            "stateMutability": "nonpayable",
-            "superFunction": null,
-            "visibility": "public"
-          },
-          {
-            "body": {
-              "id": 205,
-              "nodeType": "Block",
-              "src": "1530:564:1",
+              "src": "1985:351:1",
               "statements": [
                 {
                   "expression": {
@@ -1437,292 +1064,7 @@
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
                         },
-                        "id": 165,
-                        "isConstant": false,
-                        "isLValue": false,
-                        "isPure": false,
-                        "lValueRequested": false,
-                        "leftExpression": {
-                          "argumentTypes": null,
-                          "expression": {
-                            "argumentTypes": null,
-                            "baseExpression": {
-                              "argumentTypes": null,
-                              "id": 159,
-                              "name": "voters",
-                              "nodeType": "Identifier",
-                              "overloadedDeclarations": [],
-                              "referencedDeclaration": 84,
-                              "src": "1586:6:1",
-                              "typeDescriptions": {
-                                "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
-                                "typeString": "mapping(address => struct Election.Voter storage ref)"
-                              }
-                            },
-                            "id": 162,
-                            "indexExpression": {
-                              "argumentTypes": null,
-                              "expression": {
-                                "argumentTypes": null,
-                                "id": 160,
-                                "name": "msg",
-                                "nodeType": "Identifier",
-                                "overloadedDeclarations": [],
-                                "referencedDeclaration": 222,
-                                "src": "1593:3:1",
-                                "typeDescriptions": {
-                                  "typeIdentifier": "t_magic_message",
-                                  "typeString": "msg"
-                                }
-                              },
-                              "id": 161,
-                              "isConstant": false,
-                              "isLValue": false,
-                              "isPure": false,
-                              "lValueRequested": false,
-                              "memberName": "sender",
-                              "nodeType": "MemberAccess",
-                              "referencedDeclaration": null,
-                              "src": "1593:10:1",
-                              "typeDescriptions": {
-                                "typeIdentifier": "t_address",
-                                "typeString": "address"
-                              }
-                            },
-                            "isConstant": false,
-                            "isLValue": true,
-                            "isPure": false,
-                            "lValueRequested": false,
-                            "nodeType": "IndexAccess",
-                            "src": "1586:18:1",
-                            "typeDescriptions": {
-                              "typeIdentifier": "t_struct$_Voter_$76_storage",
-                              "typeString": "struct Election.Voter storage ref"
-                            }
-                          },
-                          "id": 163,
-                          "isConstant": false,
-                          "isLValue": true,
-                          "isPure": false,
-                          "lValueRequested": false,
-                          "memberName": "eligibility",
-                          "nodeType": "MemberAccess",
-                          "referencedDeclaration": 69,
-                          "src": "1586:30:1",
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_bool",
-                            "typeString": "bool"
-                          }
-                        },
-                        "nodeType": "BinaryOperation",
-                        "operator": "==",
-                        "rightExpression": {
-                          "argumentTypes": null,
-                          "hexValue": "74727565",
-                          "id": 164,
-                          "isConstant": false,
-                          "isLValue": false,
-                          "isPure": true,
-                          "kind": "bool",
-                          "lValueRequested": false,
-                          "nodeType": "Literal",
-                          "src": "1620:4:1",
-                          "subdenomination": null,
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_bool",
-                            "typeString": "bool"
-                          },
-                          "value": "true"
-                        },
-                        "src": "1586:38:1",
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_bool",
-                          "typeString": "bool"
-                        }
-                      }
-                    ],
-                    "expression": {
-                      "argumentTypes": [
-                        {
-                          "typeIdentifier": "t_bool",
-                          "typeString": "bool"
-                        }
-                      ],
-                      "id": 158,
-                      "name": "require",
-                      "nodeType": "Identifier",
-                      "overloadedDeclarations": [
-                        225,
-                        226
-                      ],
-                      "referencedDeclaration": 225,
-                      "src": "1578:7:1",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
-                        "typeString": "function (bool) pure"
-                      }
-                    },
-                    "id": 166,
-                    "isConstant": false,
-                    "isLValue": false,
-                    "isPure": false,
-                    "kind": "functionCall",
-                    "lValueRequested": false,
-                    "names": [],
-                    "nodeType": "FunctionCall",
-                    "src": "1578:47:1",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_tuple$__$",
-                      "typeString": "tuple()"
-                    }
-                  },
-                  "id": 167,
-                  "nodeType": "ExpressionStatement",
-                  "src": "1578:47:1"
-                },
-                {
-                  "expression": {
-                    "argumentTypes": null,
-                    "arguments": [
-                      {
-                        "argumentTypes": null,
-                        "id": 174,
-                        "isConstant": false,
-                        "isLValue": false,
-                        "isPure": false,
-                        "lValueRequested": false,
-                        "nodeType": "UnaryOperation",
-                        "operator": "!",
-                        "prefix": true,
-                        "src": "1697:28:1",
-                        "subExpression": {
-                          "argumentTypes": null,
-                          "expression": {
-                            "argumentTypes": null,
-                            "baseExpression": {
-                              "argumentTypes": null,
-                              "id": 169,
-                              "name": "voters",
-                              "nodeType": "Identifier",
-                              "overloadedDeclarations": [],
-                              "referencedDeclaration": 84,
-                              "src": "1698:6:1",
-                              "typeDescriptions": {
-                                "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
-                                "typeString": "mapping(address => struct Election.Voter storage ref)"
-                              }
-                            },
-                            "id": 172,
-                            "indexExpression": {
-                              "argumentTypes": null,
-                              "expression": {
-                                "argumentTypes": null,
-                                "id": 170,
-                                "name": "msg",
-                                "nodeType": "Identifier",
-                                "overloadedDeclarations": [],
-                                "referencedDeclaration": 222,
-                                "src": "1705:3:1",
-                                "typeDescriptions": {
-                                  "typeIdentifier": "t_magic_message",
-                                  "typeString": "msg"
-                                }
-                              },
-                              "id": 171,
-                              "isConstant": false,
-                              "isLValue": false,
-                              "isPure": false,
-                              "lValueRequested": false,
-                              "memberName": "sender",
-                              "nodeType": "MemberAccess",
-                              "referencedDeclaration": null,
-                              "src": "1705:10:1",
-                              "typeDescriptions": {
-                                "typeIdentifier": "t_address",
-                                "typeString": "address"
-                              }
-                            },
-                            "isConstant": false,
-                            "isLValue": true,
-                            "isPure": false,
-                            "lValueRequested": false,
-                            "nodeType": "IndexAccess",
-                            "src": "1698:18:1",
-                            "typeDescriptions": {
-                              "typeIdentifier": "t_struct$_Voter_$76_storage",
-                              "typeString": "struct Election.Voter storage ref"
-                            }
-                          },
-                          "id": 173,
-                          "isConstant": false,
-                          "isLValue": true,
-                          "isPure": false,
-                          "lValueRequested": false,
-                          "memberName": "hasVoted",
-                          "nodeType": "MemberAccess",
-                          "referencedDeclaration": 71,
-                          "src": "1698:27:1",
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_bool",
-                            "typeString": "bool"
-                          }
-                        },
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_bool",
-                          "typeString": "bool"
-                        }
-                      }
-                    ],
-                    "expression": {
-                      "argumentTypes": [
-                        {
-                          "typeIdentifier": "t_bool",
-                          "typeString": "bool"
-                        }
-                      ],
-                      "id": 168,
-                      "name": "require",
-                      "nodeType": "Identifier",
-                      "overloadedDeclarations": [
-                        225,
-                        226
-                      ],
-                      "referencedDeclaration": 225,
-                      "src": "1689:7:1",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
-                        "typeString": "function (bool) pure"
-                      }
-                    },
-                    "id": 175,
-                    "isConstant": false,
-                    "isLValue": false,
-                    "isPure": false,
-                    "kind": "functionCall",
-                    "lValueRequested": false,
-                    "names": [],
-                    "nodeType": "FunctionCall",
-                    "src": "1689:37:1",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_tuple$__$",
-                      "typeString": "tuple()"
-                    }
-                  },
-                  "id": 176,
-                  "nodeType": "ExpressionStatement",
-                  "src": "1689:37:1"
-                },
-                {
-                  "expression": {
-                    "argumentTypes": null,
-                    "arguments": [
-                      {
-                        "argumentTypes": null,
-                        "commonType": {
-                          "typeIdentifier": "t_bool",
-                          "typeString": "bool"
-                        },
-                        "id": 184,
+                        "id": 147,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -1730,48 +1072,107 @@
                         "leftExpression": {
                           "argumentTypes": null,
                           "commonType": {
-                            "typeIdentifier": "t_uint256",
-                            "typeString": "uint256"
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
                           },
-                          "id": 180,
+                          "id": 139,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftExpression": {
                             "argumentTypes": null,
-                            "id": 178,
-                            "name": "_candidateId",
-                            "nodeType": "Identifier",
-                            "overloadedDeclarations": [],
-                            "referencedDeclaration": 155,
-                            "src": "1785:12:1",
+                            "expression": {
+                              "argumentTypes": null,
+                              "baseExpression": {
+                                "argumentTypes": null,
+                                "id": 133,
+                                "name": "voters",
+                                "nodeType": "Identifier",
+                                "overloadedDeclarations": [],
+                                "referencedDeclaration": 84,
+                                "src": "1996:6:1",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+                                  "typeString": "mapping(address => struct Election.Voter storage ref)"
+                                }
+                              },
+                              "id": 136,
+                              "indexExpression": {
+                                "argumentTypes": null,
+                                "expression": {
+                                  "argumentTypes": null,
+                                  "id": 134,
+                                  "name": "msg",
+                                  "nodeType": "Identifier",
+                                  "overloadedDeclarations": [],
+                                  "referencedDeclaration": 240,
+                                  "src": "2003:3:1",
+                                  "typeDescriptions": {
+                                    "typeIdentifier": "t_magic_message",
+                                    "typeString": "msg"
+                                  }
+                                },
+                                "id": 135,
+                                "isConstant": false,
+                                "isLValue": false,
+                                "isPure": false,
+                                "lValueRequested": false,
+                                "memberName": "sender",
+                                "nodeType": "MemberAccess",
+                                "referencedDeclaration": null,
+                                "src": "2003:10:1",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_address",
+                                  "typeString": "address"
+                                }
+                              },
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "nodeType": "IndexAccess",
+                              "src": "1996:18:1",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_struct$_Voter_$76_storage",
+                                "typeString": "struct Election.Voter storage ref"
+                              }
+                            },
+                            "id": 137,
+                            "isConstant": false,
+                            "isLValue": true,
+                            "isPure": false,
+                            "lValueRequested": false,
+                            "memberName": "eligibility",
+                            "nodeType": "MemberAccess",
+                            "referencedDeclaration": 69,
+                            "src": "1996:30:1",
                             "typeDescriptions": {
-                              "typeIdentifier": "t_uint256",
-                              "typeString": "uint256"
+                              "typeIdentifier": "t_bool",
+                              "typeString": "bool"
                             }
                           },
                           "nodeType": "BinaryOperation",
-                          "operator": ">",
+                          "operator": "==",
                           "rightExpression": {
                             "argumentTypes": null,
-                            "hexValue": "30",
-                            "id": 179,
+                            "hexValue": "66616c7365",
+                            "id": 138,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
-                            "kind": "number",
+                            "kind": "bool",
                             "lValueRequested": false,
                             "nodeType": "Literal",
-                            "src": "1800:1:1",
+                            "src": "2030:5:1",
                             "subdenomination": null,
                             "typeDescriptions": {
-                              "typeIdentifier": "t_rational_0_by_1",
-                              "typeString": "int_const 0"
+                              "typeIdentifier": "t_bool",
+                              "typeString": "bool"
                             },
-                            "value": "0"
+                            "value": "false"
                           },
-                          "src": "1785:16:1",
+                          "src": "1996:39:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
@@ -1785,46 +1186,105 @@
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
                           },
-                          "id": 183,
+                          "id": 146,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftExpression": {
                             "argumentTypes": null,
-                            "id": 181,
-                            "name": "_candidateId",
-                            "nodeType": "Identifier",
-                            "overloadedDeclarations": [],
-                            "referencedDeclaration": 155,
-                            "src": "1805:12:1",
+                            "expression": {
+                              "argumentTypes": null,
+                              "baseExpression": {
+                                "argumentTypes": null,
+                                "id": 140,
+                                "name": "voters",
+                                "nodeType": "Identifier",
+                                "overloadedDeclarations": [],
+                                "referencedDeclaration": 84,
+                                "src": "2039:6:1",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+                                  "typeString": "mapping(address => struct Election.Voter storage ref)"
+                                }
+                              },
+                              "id": 143,
+                              "indexExpression": {
+                                "argumentTypes": null,
+                                "expression": {
+                                  "argumentTypes": null,
+                                  "id": 141,
+                                  "name": "msg",
+                                  "nodeType": "Identifier",
+                                  "overloadedDeclarations": [],
+                                  "referencedDeclaration": 240,
+                                  "src": "2046:3:1",
+                                  "typeDescriptions": {
+                                    "typeIdentifier": "t_magic_message",
+                                    "typeString": "msg"
+                                  }
+                                },
+                                "id": 142,
+                                "isConstant": false,
+                                "isLValue": false,
+                                "isPure": false,
+                                "lValueRequested": false,
+                                "memberName": "sender",
+                                "nodeType": "MemberAccess",
+                                "referencedDeclaration": null,
+                                "src": "2046:10:1",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_address",
+                                  "typeString": "address"
+                                }
+                              },
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "nodeType": "IndexAccess",
+                              "src": "2039:18:1",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_struct$_Voter_$76_storage",
+                                "typeString": "struct Election.Voter storage ref"
+                              }
+                            },
+                            "id": 144,
+                            "isConstant": false,
+                            "isLValue": true,
+                            "isPure": false,
+                            "lValueRequested": false,
+                            "memberName": "NID",
+                            "nodeType": "MemberAccess",
+                            "referencedDeclaration": 67,
+                            "src": "2039:22:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
                             }
                           },
                           "nodeType": "BinaryOperation",
-                          "operator": "<=",
+                          "operator": "!=",
                           "rightExpression": {
                             "argumentTypes": null,
-                            "id": 182,
-                            "name": "candidatesCount",
+                            "id": 145,
+                            "name": "_nationalID",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 90,
-                            "src": "1821:15:1",
+                            "referencedDeclaration": 129,
+                            "src": "2065:11:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
                             }
                           },
-                          "src": "1805:31:1",
+                          "src": "2039:37:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
                           }
                         },
-                        "src": "1785:51:1",
+                        "src": "1996:80:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
@@ -1838,21 +1298,21 @@
                           "typeString": "bool"
                         }
                       ],
-                      "id": 177,
+                      "id": 132,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        225,
-                        226
+                        243,
+                        244
                       ],
-                      "referencedDeclaration": 225,
-                      "src": "1777:7:1",
+                      "referencedDeclaration": 243,
+                      "src": "1988:7:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
                         "typeString": "function (bool) pure"
                       }
                     },
-                    "id": 185,
+                    "id": 148,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -1860,130 +1320,20 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1777:60:1",
+                    "src": "1988:89:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 186,
+                  "id": 149,
                   "nodeType": "ExpressionStatement",
-                  "src": "1777:60:1"
+                  "src": "1988:89:1"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 193,
-                    "isConstant": false,
-                    "isLValue": false,
-                    "isPure": false,
-                    "lValueRequested": false,
-                    "leftHandSide": {
-                      "argumentTypes": null,
-                      "expression": {
-                        "argumentTypes": null,
-                        "baseExpression": {
-                          "argumentTypes": null,
-                          "id": 187,
-                          "name": "voters",
-                          "nodeType": "Identifier",
-                          "overloadedDeclarations": [],
-                          "referencedDeclaration": 84,
-                          "src": "1890:6:1",
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
-                            "typeString": "mapping(address => struct Election.Voter storage ref)"
-                          }
-                        },
-                        "id": 190,
-                        "indexExpression": {
-                          "argumentTypes": null,
-                          "expression": {
-                            "argumentTypes": null,
-                            "id": 188,
-                            "name": "msg",
-                            "nodeType": "Identifier",
-                            "overloadedDeclarations": [],
-                            "referencedDeclaration": 222,
-                            "src": "1897:3:1",
-                            "typeDescriptions": {
-                              "typeIdentifier": "t_magic_message",
-                              "typeString": "msg"
-                            }
-                          },
-                          "id": 189,
-                          "isConstant": false,
-                          "isLValue": false,
-                          "isPure": false,
-                          "lValueRequested": false,
-                          "memberName": "sender",
-                          "nodeType": "MemberAccess",
-                          "referencedDeclaration": null,
-                          "src": "1897:10:1",
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_address",
-                            "typeString": "address"
-                          }
-                        },
-                        "isConstant": false,
-                        "isLValue": true,
-                        "isPure": false,
-                        "lValueRequested": false,
-                        "nodeType": "IndexAccess",
-                        "src": "1890:18:1",
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_struct$_Voter_$76_storage",
-                          "typeString": "struct Election.Voter storage ref"
-                        }
-                      },
-                      "id": 191,
-                      "isConstant": false,
-                      "isLValue": true,
-                      "isPure": false,
-                      "lValueRequested": true,
-                      "memberName": "hasVoted",
-                      "nodeType": "MemberAccess",
-                      "referencedDeclaration": 71,
-                      "src": "1890:27:1",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_bool",
-                        "typeString": "bool"
-                      }
-                    },
-                    "nodeType": "Assignment",
-                    "operator": "=",
-                    "rightHandSide": {
-                      "argumentTypes": null,
-                      "hexValue": "74727565",
-                      "id": 192,
-                      "isConstant": false,
-                      "isLValue": false,
-                      "isPure": true,
-                      "kind": "bool",
-                      "lValueRequested": false,
-                      "nodeType": "Literal",
-                      "src": "1920:4:1",
-                      "subdenomination": null,
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_bool",
-                        "typeString": "bool"
-                      },
-                      "value": "true"
-                    },
-                    "src": "1890:34:1",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_bool",
-                      "typeString": "bool"
-                    }
-                  },
-                  "id": 194,
-                  "nodeType": "ExpressionStatement",
-                  "src": "1890:34:1"
-                },
-                {
-                  "expression": {
-                    "argumentTypes": null,
-                    "id": 199,
+                    "id": 151,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -1991,58 +1341,15 @@
                     "nodeType": "UnaryOperation",
                     "operator": "++",
                     "prefix": false,
-                    "src": "1977:36:1",
+                    "src": "2167:13:1",
                     "subExpression": {
                       "argumentTypes": null,
-                      "expression": {
-                        "argumentTypes": null,
-                        "baseExpression": {
-                          "argumentTypes": null,
-                          "id": 195,
-                          "name": "candidates",
-                          "nodeType": "Identifier",
-                          "overloadedDeclarations": [],
-                          "referencedDeclaration": 80,
-                          "src": "1977:10:1",
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_mapping$_t_uint256_$_t_struct$_Candidate_$65_storage_$",
-                            "typeString": "mapping(uint256 => struct Election.Candidate storage ref)"
-                          }
-                        },
-                        "id": 197,
-                        "indexExpression": {
-                          "argumentTypes": null,
-                          "id": 196,
-                          "name": "_candidateId",
-                          "nodeType": "Identifier",
-                          "overloadedDeclarations": [],
-                          "referencedDeclaration": 155,
-                          "src": "1988:12:1",
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_uint256",
-                            "typeString": "uint256"
-                          }
-                        },
-                        "isConstant": false,
-                        "isLValue": true,
-                        "isPure": false,
-                        "lValueRequested": false,
-                        "nodeType": "IndexAccess",
-                        "src": "1977:24:1",
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_struct$_Candidate_$65_storage",
-                          "typeString": "struct Election.Candidate storage ref"
-                        }
-                      },
-                      "id": 198,
-                      "isConstant": false,
-                      "isLValue": true,
-                      "isPure": false,
-                      "lValueRequested": true,
-                      "memberName": "voteCount",
-                      "nodeType": "MemberAccess",
-                      "referencedDeclaration": 64,
-                      "src": "1977:34:1",
+                      "id": 150,
+                      "name": "votersCount",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 96,
+                      "src": "2167:11:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
@@ -2053,9 +1360,222 @@
                       "typeString": "uint256"
                     }
                   },
-                  "id": 200,
+                  "id": 152,
                   "nodeType": "ExpressionStatement",
-                  "src": "1977:36:1"
+                  "src": "2167:13:1"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "id": 164,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "argumentTypes": null,
+                      "baseExpression": {
+                        "argumentTypes": null,
+                        "id": 153,
+                        "name": "voters",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 84,
+                        "src": "2183:6:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+                          "typeString": "mapping(address => struct Election.Voter storage ref)"
+                        }
+                      },
+                      "id": 156,
+                      "indexExpression": {
+                        "argumentTypes": null,
+                        "expression": {
+                          "argumentTypes": null,
+                          "id": 154,
+                          "name": "msg",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 240,
+                          "src": "2190:3:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_magic_message",
+                            "typeString": "msg"
+                          }
+                        },
+                        "id": 155,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "memberName": "sender",
+                        "nodeType": "MemberAccess",
+                        "referencedDeclaration": null,
+                        "src": "2190:10:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      "isConstant": false,
+                      "isLValue": true,
+                      "isPure": false,
+                      "lValueRequested": true,
+                      "nodeType": "IndexAccess",
+                      "src": "2183:18:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_struct$_Voter_$76_storage",
+                        "typeString": "struct Election.Voter storage ref"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "argumentTypes": null,
+                      "arguments": [
+                        {
+                          "argumentTypes": null,
+                          "id": 158,
+                          "name": "_nationalID",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 129,
+                          "src": "2210:11:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        {
+                          "argumentTypes": null,
+                          "hexValue": "74727565",
+                          "id": 159,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "bool",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "2222:4:1",
+                          "subdenomination": null,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          },
+                          "value": "true"
+                        },
+                        {
+                          "argumentTypes": null,
+                          "hexValue": "66616c7365",
+                          "id": 160,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "bool",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "2227:5:1",
+                          "subdenomination": null,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          },
+                          "value": "false"
+                        },
+                        {
+                          "argumentTypes": null,
+                          "hexValue": "30",
+                          "id": 161,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "number",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "2233:1:1",
+                          "subdenomination": null,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_rational_0_by_1",
+                            "typeString": "int_const 0"
+                          },
+                          "value": "0"
+                        },
+                        {
+                          "argumentTypes": null,
+                          "hexValue": "30",
+                          "id": 162,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "number",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "2235:1:1",
+                          "subdenomination": null,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_rational_0_by_1",
+                            "typeString": "int_const 0"
+                          },
+                          "value": "0"
+                        }
+                      ],
+                      "expression": {
+                        "argumentTypes": [
+                          {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          },
+                          {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          },
+                          {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          },
+                          {
+                            "typeIdentifier": "t_rational_0_by_1",
+                            "typeString": "int_const 0"
+                          },
+                          {
+                            "typeIdentifier": "t_rational_0_by_1",
+                            "typeString": "int_const 0"
+                          }
+                        ],
+                        "id": 157,
+                        "name": "Voter",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 76,
+                        "src": "2204:5:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_type$_t_struct$_Voter_$76_storage_ptr_$",
+                          "typeString": "type(struct Election.Voter storage pointer)"
+                        }
+                      },
+                      "id": 163,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "kind": "structConstructorCall",
+                      "lValueRequested": false,
+                      "names": [],
+                      "nodeType": "FunctionCall",
+                      "src": "2204:33:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_struct$_Voter_$76_memory",
+                        "typeString": "struct Election.Voter memory"
+                      }
+                    },
+                    "src": "2183:54:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_struct$_Voter_$76_storage",
+                      "typeString": "struct Election.Voter storage ref"
+                    }
+                  },
+                  "id": 165,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2183:54:1"
                 },
                 {
                   "eventCall": {
@@ -2063,12 +1583,12 @@
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 202,
-                        "name": "_candidateId",
+                        "id": 167,
+                        "name": "_nationalID",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 155,
-                        "src": "2073:12:1",
+                        "referencedDeclaration": 129,
+                        "src": "2320:11:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
@@ -2082,15 +1602,520 @@
                           "typeString": "uint256"
                         }
                       ],
-                      "id": 201,
-                      "name": "votedEvent",
+                      "id": 166,
+                      "name": "newVoter",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 88,
-                      "src": "2062:10:1",
+                      "referencedDeclaration": 92,
+                      "src": "2311:8:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_event_nonpayable$_t_uint256_$returns$__$",
                         "typeString": "function (uint256)"
+                      }
+                    },
+                    "id": 168,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "2311:21:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 169,
+                  "nodeType": "EmitStatement",
+                  "src": "2306:26:1"
+                }
+              ]
+            },
+            "documentation": null,
+            "id": 171,
+            "implemented": true,
+            "isConstructor": false,
+            "isDeclaredConst": false,
+            "modifiers": [],
+            "name": "addVoter",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 130,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 129,
+                  "name": "_nationalID",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 171,
+                  "src": "1960:16:1",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 128,
+                    "name": "uint",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1960:4:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                }
+              ],
+              "src": "1959:18:1"
+            },
+            "payable": false,
+            "returnParameters": {
+              "id": 131,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "1985:0:1"
+            },
+            "scope": 225,
+            "src": "1942:394:1",
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          {
+            "body": {
+              "id": 223,
+              "nodeType": "Block",
+              "src": "2380:564:1",
+              "statements": [
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "arguments": [
+                      {
+                        "argumentTypes": null,
+                        "commonType": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        },
+                        "id": 183,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftExpression": {
+                          "argumentTypes": null,
+                          "expression": {
+                            "argumentTypes": null,
+                            "baseExpression": {
+                              "argumentTypes": null,
+                              "id": 177,
+                              "name": "voters",
+                              "nodeType": "Identifier",
+                              "overloadedDeclarations": [],
+                              "referencedDeclaration": 84,
+                              "src": "2436:6:1",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+                                "typeString": "mapping(address => struct Election.Voter storage ref)"
+                              }
+                            },
+                            "id": 180,
+                            "indexExpression": {
+                              "argumentTypes": null,
+                              "expression": {
+                                "argumentTypes": null,
+                                "id": 178,
+                                "name": "msg",
+                                "nodeType": "Identifier",
+                                "overloadedDeclarations": [],
+                                "referencedDeclaration": 240,
+                                "src": "2443:3:1",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_magic_message",
+                                  "typeString": "msg"
+                                }
+                              },
+                              "id": 179,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "memberName": "sender",
+                              "nodeType": "MemberAccess",
+                              "referencedDeclaration": null,
+                              "src": "2443:10:1",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_address",
+                                "typeString": "address"
+                              }
+                            },
+                            "isConstant": false,
+                            "isLValue": true,
+                            "isPure": false,
+                            "lValueRequested": false,
+                            "nodeType": "IndexAccess",
+                            "src": "2436:18:1",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_struct$_Voter_$76_storage",
+                              "typeString": "struct Election.Voter storage ref"
+                            }
+                          },
+                          "id": 181,
+                          "isConstant": false,
+                          "isLValue": true,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "memberName": "eligibility",
+                          "nodeType": "MemberAccess",
+                          "referencedDeclaration": 69,
+                          "src": "2436:30:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          }
+                        },
+                        "nodeType": "BinaryOperation",
+                        "operator": "==",
+                        "rightExpression": {
+                          "argumentTypes": null,
+                          "hexValue": "74727565",
+                          "id": 182,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "bool",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "2470:4:1",
+                          "subdenomination": null,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          },
+                          "value": "true"
+                        },
+                        "src": "2436:38:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      ],
+                      "id": 176,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        243,
+                        244
+                      ],
+                      "referencedDeclaration": 243,
+                      "src": "2428:7:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
+                        "typeString": "function (bool) pure"
+                      }
+                    },
+                    "id": 184,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "2428:47:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 185,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2428:47:1"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "arguments": [
+                      {
+                        "argumentTypes": null,
+                        "id": 192,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "nodeType": "UnaryOperation",
+                        "operator": "!",
+                        "prefix": true,
+                        "src": "2547:28:1",
+                        "subExpression": {
+                          "argumentTypes": null,
+                          "expression": {
+                            "argumentTypes": null,
+                            "baseExpression": {
+                              "argumentTypes": null,
+                              "id": 187,
+                              "name": "voters",
+                              "nodeType": "Identifier",
+                              "overloadedDeclarations": [],
+                              "referencedDeclaration": 84,
+                              "src": "2548:6:1",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+                                "typeString": "mapping(address => struct Election.Voter storage ref)"
+                              }
+                            },
+                            "id": 190,
+                            "indexExpression": {
+                              "argumentTypes": null,
+                              "expression": {
+                                "argumentTypes": null,
+                                "id": 188,
+                                "name": "msg",
+                                "nodeType": "Identifier",
+                                "overloadedDeclarations": [],
+                                "referencedDeclaration": 240,
+                                "src": "2555:3:1",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_magic_message",
+                                  "typeString": "msg"
+                                }
+                              },
+                              "id": 189,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "memberName": "sender",
+                              "nodeType": "MemberAccess",
+                              "referencedDeclaration": null,
+                              "src": "2555:10:1",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_address",
+                                "typeString": "address"
+                              }
+                            },
+                            "isConstant": false,
+                            "isLValue": true,
+                            "isPure": false,
+                            "lValueRequested": false,
+                            "nodeType": "IndexAccess",
+                            "src": "2548:18:1",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_struct$_Voter_$76_storage",
+                              "typeString": "struct Election.Voter storage ref"
+                            }
+                          },
+                          "id": 191,
+                          "isConstant": false,
+                          "isLValue": true,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "memberName": "hasVoted",
+                          "nodeType": "MemberAccess",
+                          "referencedDeclaration": 71,
+                          "src": "2548:27:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          }
+                        },
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      ],
+                      "id": 186,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        243,
+                        244
+                      ],
+                      "referencedDeclaration": 243,
+                      "src": "2539:7:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
+                        "typeString": "function (bool) pure"
+                      }
+                    },
+                    "id": 193,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "2539:37:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 194,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2539:37:1"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "arguments": [
+                      {
+                        "argumentTypes": null,
+                        "commonType": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        },
+                        "id": 202,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftExpression": {
+                          "argumentTypes": null,
+                          "commonType": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          },
+                          "id": 198,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "leftExpression": {
+                            "argumentTypes": null,
+                            "id": 196,
+                            "name": "_candidateId",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 173,
+                            "src": "2635:12:1",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_uint256",
+                              "typeString": "uint256"
+                            }
+                          },
+                          "nodeType": "BinaryOperation",
+                          "operator": ">",
+                          "rightExpression": {
+                            "argumentTypes": null,
+                            "hexValue": "30",
+                            "id": 197,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "kind": "number",
+                            "lValueRequested": false,
+                            "nodeType": "Literal",
+                            "src": "2650:1:1",
+                            "subdenomination": null,
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_rational_0_by_1",
+                              "typeString": "int_const 0"
+                            },
+                            "value": "0"
+                          },
+                          "src": "2635:16:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          }
+                        },
+                        "nodeType": "BinaryOperation",
+                        "operator": "&&",
+                        "rightExpression": {
+                          "argumentTypes": null,
+                          "commonType": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          },
+                          "id": 201,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "leftExpression": {
+                            "argumentTypes": null,
+                            "id": 199,
+                            "name": "_candidateId",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 173,
+                            "src": "2655:12:1",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_uint256",
+                              "typeString": "uint256"
+                            }
+                          },
+                          "nodeType": "BinaryOperation",
+                          "operator": "<=",
+                          "rightExpression": {
+                            "argumentTypes": null,
+                            "id": 200,
+                            "name": "candidatesCount",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 94,
+                            "src": "2671:15:1",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_uint256",
+                              "typeString": "uint256"
+                            }
+                          },
+                          "src": "2655:31:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          }
+                        },
+                        "src": "2635:51:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      ],
+                      "id": 195,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        243,
+                        244
+                      ],
+                      "referencedDeclaration": 243,
+                      "src": "2627:7:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
+                        "typeString": "function (bool) pure"
                       }
                     },
                     "id": 203,
@@ -2101,20 +2126,261 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "2062:24:1",
+                    "src": "2627:60:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
                   "id": 204,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2627:60:1"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "id": 211,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "argumentTypes": null,
+                      "expression": {
+                        "argumentTypes": null,
+                        "baseExpression": {
+                          "argumentTypes": null,
+                          "id": 205,
+                          "name": "voters",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 84,
+                          "src": "2740:6:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+                            "typeString": "mapping(address => struct Election.Voter storage ref)"
+                          }
+                        },
+                        "id": 208,
+                        "indexExpression": {
+                          "argumentTypes": null,
+                          "expression": {
+                            "argumentTypes": null,
+                            "id": 206,
+                            "name": "msg",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 240,
+                            "src": "2747:3:1",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_magic_message",
+                              "typeString": "msg"
+                            }
+                          },
+                          "id": 207,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "memberName": "sender",
+                          "nodeType": "MemberAccess",
+                          "referencedDeclaration": null,
+                          "src": "2747:10:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          }
+                        },
+                        "isConstant": false,
+                        "isLValue": true,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "nodeType": "IndexAccess",
+                        "src": "2740:18:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_struct$_Voter_$76_storage",
+                          "typeString": "struct Election.Voter storage ref"
+                        }
+                      },
+                      "id": 209,
+                      "isConstant": false,
+                      "isLValue": true,
+                      "isPure": false,
+                      "lValueRequested": true,
+                      "memberName": "hasVoted",
+                      "nodeType": "MemberAccess",
+                      "referencedDeclaration": 71,
+                      "src": "2740:27:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "argumentTypes": null,
+                      "hexValue": "74727565",
+                      "id": 210,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "kind": "bool",
+                      "lValueRequested": false,
+                      "nodeType": "Literal",
+                      "src": "2770:4:1",
+                      "subdenomination": null,
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      },
+                      "value": "true"
+                    },
+                    "src": "2740:34:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bool",
+                      "typeString": "bool"
+                    }
+                  },
+                  "id": 212,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2740:34:1"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "id": 217,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "nodeType": "UnaryOperation",
+                    "operator": "++",
+                    "prefix": false,
+                    "src": "2827:36:1",
+                    "subExpression": {
+                      "argumentTypes": null,
+                      "expression": {
+                        "argumentTypes": null,
+                        "baseExpression": {
+                          "argumentTypes": null,
+                          "id": 213,
+                          "name": "candidates",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 80,
+                          "src": "2827:10:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_mapping$_t_uint256_$_t_struct$_Candidate_$65_storage_$",
+                            "typeString": "mapping(uint256 => struct Election.Candidate storage ref)"
+                          }
+                        },
+                        "id": 215,
+                        "indexExpression": {
+                          "argumentTypes": null,
+                          "id": 214,
+                          "name": "_candidateId",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 173,
+                          "src": "2838:12:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        "isConstant": false,
+                        "isLValue": true,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "nodeType": "IndexAccess",
+                        "src": "2827:24:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_struct$_Candidate_$65_storage",
+                          "typeString": "struct Election.Candidate storage ref"
+                        }
+                      },
+                      "id": 216,
+                      "isConstant": false,
+                      "isLValue": true,
+                      "isPure": false,
+                      "lValueRequested": true,
+                      "memberName": "voteCount",
+                      "nodeType": "MemberAccess",
+                      "referencedDeclaration": 64,
+                      "src": "2827:34:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "id": 218,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2827:36:1"
+                },
+                {
+                  "eventCall": {
+                    "argumentTypes": null,
+                    "arguments": [
+                      {
+                        "argumentTypes": null,
+                        "id": 220,
+                        "name": "_candidateId",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 173,
+                        "src": "2923:12:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      ],
+                      "id": 219,
+                      "name": "votedEvent",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 88,
+                      "src": "2912:10:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_event_nonpayable$_t_uint256_$returns$__$",
+                        "typeString": "function (uint256)"
+                      }
+                    },
+                    "id": 221,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "2912:24:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 222,
                   "nodeType": "EmitStatement",
-                  "src": "2057:29:1"
+                  "src": "2907:29:1"
                 }
               ]
             },
             "documentation": null,
-            "id": 206,
+            "id": 224,
             "implemented": true,
             "isConstructor": false,
             "isDeclaredConst": false,
@@ -2122,16 +2388,16 @@
             "name": "vote",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 156,
+              "id": 174,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 155,
+                  "id": 173,
                   "name": "_candidateId",
                   "nodeType": "VariableDeclaration",
-                  "scope": 206,
-                  "src": "1504:17:1",
+                  "scope": 224,
+                  "src": "2354:17:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2139,10 +2405,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 154,
+                    "id": 172,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1504:4:1",
+                    "src": "2354:4:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -2152,36 +2418,36 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "1503:19:1"
+              "src": "2353:19:1"
             },
             "payable": false,
             "returnParameters": {
-              "id": 157,
+              "id": 175,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "1530:0:1"
+              "src": "2380:0:1"
             },
-            "scope": 207,
-            "src": "1490:604:1",
+            "scope": 225,
+            "src": "2340:604:1",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
           }
         ],
-        "scope": 208,
-        "src": "27:2070:1"
+        "scope": 226,
+        "src": "28:2919:1"
       }
     ],
-    "src": "0:2099:1"
+    "src": "0:2949:1"
   },
   "legacyAST": {
     "absolutePath": "/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/election.sol",
     "exportedSymbols": {
       "Election": [
-        207
+        225
       ]
     },
-    "id": 208,
+    "id": 226,
     "nodeType": "SourceUnit",
     "nodes": [
       {
@@ -2190,10 +2456,10 @@
           "solidity",
           "^",
           "0.4",
-          ".2"
+          ".23"
         ],
         "nodeType": "PragmaDirective",
-        "src": "0:23:1"
+        "src": "0:24:1"
       },
       {
         "baseContracts": [],
@@ -2201,9 +2467,9 @@
         "contractKind": "contract",
         "documentation": null,
         "fullyImplemented": true,
-        "id": 207,
+        "id": 225,
         "linearizedBaseContracts": [
-          207
+          225
         ],
         "name": "Election",
         "nodeType": "ContractDefinition",
@@ -2218,7 +2484,7 @@
                 "name": "id",
                 "nodeType": "VariableDeclaration",
                 "scope": 65,
-                "src": "92:7:1",
+                "src": "93:7:1",
                 "stateVariable": false,
                 "storageLocation": "default",
                 "typeDescriptions": {
@@ -2229,7 +2495,7 @@
                   "id": 59,
                   "name": "uint",
                   "nodeType": "ElementaryTypeName",
-                  "src": "92:4:1",
+                  "src": "93:4:1",
                   "typeDescriptions": {
                     "typeIdentifier": "t_uint256",
                     "typeString": "uint256"
@@ -2244,7 +2510,7 @@
                 "name": "name",
                 "nodeType": "VariableDeclaration",
                 "scope": 65,
-                "src": "103:11:1",
+                "src": "104:11:1",
                 "stateVariable": false,
                 "storageLocation": "default",
                 "typeDescriptions": {
@@ -2255,7 +2521,7 @@
                   "id": 61,
                   "name": "string",
                   "nodeType": "ElementaryTypeName",
-                  "src": "103:6:1",
+                  "src": "104:6:1",
                   "typeDescriptions": {
                     "typeIdentifier": "t_string_storage_ptr",
                     "typeString": "string"
@@ -2270,7 +2536,7 @@
                 "name": "voteCount",
                 "nodeType": "VariableDeclaration",
                 "scope": 65,
-                "src": "118:14:1",
+                "src": "119:14:1",
                 "stateVariable": false,
                 "storageLocation": "default",
                 "typeDescriptions": {
@@ -2281,7 +2547,7 @@
                   "id": 63,
                   "name": "uint",
                   "nodeType": "ElementaryTypeName",
-                  "src": "118:4:1",
+                  "src": "119:4:1",
                   "typeDescriptions": {
                     "typeIdentifier": "t_uint256",
                     "typeString": "uint256"
@@ -2293,8 +2559,8 @@
             ],
             "name": "Candidate",
             "nodeType": "StructDefinition",
-            "scope": 207,
-            "src": "71:65:1",
+            "scope": 225,
+            "src": "72:65:1",
             "visibility": "public"
           },
           {
@@ -2307,7 +2573,7 @@
                 "name": "NID",
                 "nodeType": "VariableDeclaration",
                 "scope": 76,
-                "src": "173:8:1",
+                "src": "174:8:1",
                 "stateVariable": false,
                 "storageLocation": "default",
                 "typeDescriptions": {
@@ -2318,7 +2584,7 @@
                   "id": 66,
                   "name": "uint",
                   "nodeType": "ElementaryTypeName",
-                  "src": "173:4:1",
+                  "src": "174:4:1",
                   "typeDescriptions": {
                     "typeIdentifier": "t_uint256",
                     "typeString": "uint256"
@@ -2333,7 +2599,7 @@
                 "name": "eligibility",
                 "nodeType": "VariableDeclaration",
                 "scope": 76,
-                "src": "249:16:1",
+                "src": "250:16:1",
                 "stateVariable": false,
                 "storageLocation": "default",
                 "typeDescriptions": {
@@ -2344,7 +2610,7 @@
                   "id": 68,
                   "name": "bool",
                   "nodeType": "ElementaryTypeName",
-                  "src": "249:4:1",
+                  "src": "250:4:1",
                   "typeDescriptions": {
                     "typeIdentifier": "t_bool",
                     "typeString": "bool"
@@ -2359,7 +2625,7 @@
                 "name": "hasVoted",
                 "nodeType": "VariableDeclaration",
                 "scope": 76,
-                "src": "330:13:1",
+                "src": "331:13:1",
                 "stateVariable": false,
                 "storageLocation": "default",
                 "typeDescriptions": {
@@ -2370,7 +2636,7 @@
                   "id": 70,
                   "name": "bool",
                   "nodeType": "ElementaryTypeName",
-                  "src": "330:4:1",
+                  "src": "331:4:1",
                   "typeDescriptions": {
                     "typeIdentifier": "t_bool",
                     "typeString": "bool"
@@ -2385,7 +2651,7 @@
                 "name": "blindedVote",
                 "nodeType": "VariableDeclaration",
                 "scope": 76,
-                "src": "409:16:1",
+                "src": "410:16:1",
                 "stateVariable": false,
                 "storageLocation": "default",
                 "typeDescriptions": {
@@ -2396,7 +2662,7 @@
                   "id": 72,
                   "name": "uint",
                   "nodeType": "ElementaryTypeName",
-                  "src": "409:4:1",
+                  "src": "410:4:1",
                   "typeDescriptions": {
                     "typeIdentifier": "t_uint256",
                     "typeString": "uint256"
@@ -2411,7 +2677,7 @@
                 "name": "signedBlindedVote",
                 "nodeType": "VariableDeclaration",
                 "scope": 76,
-                "src": "468:22:1",
+                "src": "469:22:1",
                 "stateVariable": false,
                 "storageLocation": "default",
                 "typeDescriptions": {
@@ -2422,7 +2688,7 @@
                   "id": 74,
                   "name": "uint",
                   "nodeType": "ElementaryTypeName",
-                  "src": "468:4:1",
+                  "src": "469:4:1",
                   "typeDescriptions": {
                     "typeIdentifier": "t_uint256",
                     "typeString": "uint256"
@@ -2434,8 +2700,8 @@
             ],
             "name": "Voter",
             "nodeType": "StructDefinition",
-            "scope": 207,
-            "src": "155:374:1",
+            "scope": 225,
+            "src": "156:374:1",
             "visibility": "public"
           },
           {
@@ -2443,8 +2709,8 @@
             "id": 80,
             "name": "candidates",
             "nodeType": "VariableDeclaration",
-            "scope": 207,
-            "src": "557:44:1",
+            "scope": 225,
+            "src": "558:44:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -2457,14 +2723,14 @@
                 "id": 77,
                 "name": "uint",
                 "nodeType": "ElementaryTypeName",
-                "src": "565:4:1",
+                "src": "566:4:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_uint256",
                   "typeString": "uint256"
                 }
               },
               "nodeType": "Mapping",
-              "src": "557:26:1",
+              "src": "558:26:1",
               "typeDescriptions": {
                 "typeIdentifier": "t_mapping$_t_uint256_$_t_struct$_Candidate_$65_storage_$",
                 "typeString": "mapping(uint256 => struct Election.Candidate)"
@@ -2475,7 +2741,7 @@
                 "name": "Candidate",
                 "nodeType": "UserDefinedTypeName",
                 "referencedDeclaration": 65,
-                "src": "573:9:1",
+                "src": "574:9:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_struct$_Candidate_$65_storage_ptr",
                   "typeString": "struct Election.Candidate"
@@ -2490,8 +2756,8 @@
             "id": 84,
             "name": "voters",
             "nodeType": "VariableDeclaration",
-            "scope": 207,
-            "src": "641:39:1",
+            "scope": 225,
+            "src": "642:39:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -2504,14 +2770,14 @@
                 "id": 81,
                 "name": "address",
                 "nodeType": "ElementaryTypeName",
-                "src": "649:7:1",
+                "src": "650:7:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_address",
                   "typeString": "address"
                 }
               },
               "nodeType": "Mapping",
-              "src": "641:25:1",
+              "src": "642:25:1",
               "typeDescriptions": {
                 "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
                 "typeString": "mapping(address => struct Election.Voter)"
@@ -2522,7 +2788,7 @@
                 "name": "Voter",
                 "nodeType": "UserDefinedTypeName",
                 "referencedDeclaration": 76,
-                "src": "660:5:1",
+                "src": "661:5:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_struct$_Voter_$76_storage_ptr",
                   "typeString": "struct Election.Voter"
@@ -2549,7 +2815,7 @@
                   "name": "_candidateId",
                   "nodeType": "VariableDeclaration",
                   "scope": 88,
-                  "src": "745:25:1",
+                  "src": "746:25:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2560,7 +2826,7 @@
                     "id": 85,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
-                    "src": "745:4:1",
+                    "src": "746:4:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -2570,17 +2836,59 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "740:35:1"
+              "src": "741:35:1"
             },
-            "src": "724:52:1"
+            "src": "725:52:1"
+          },
+          {
+            "anonymous": false,
+            "documentation": null,
+            "id": 92,
+            "name": "newVoter",
+            "nodeType": "EventDefinition",
+            "parameters": {
+              "id": 91,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 90,
+                  "indexed": true,
+                  "name": "_nationalID",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 92,
+                  "src": "839:24:1",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 89,
+                    "name": "uint",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "839:4:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                }
+              ],
+              "src": "834:32:1"
+            },
+            "src": "820:47:1"
           },
           {
             "constant": false,
-            "id": 90,
+            "id": 94,
             "name": "candidatesCount",
             "nodeType": "VariableDeclaration",
-            "scope": 207,
-            "src": "805:27:1",
+            "scope": 225,
+            "src": "896:27:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -2588,10 +2896,10 @@
               "typeString": "uint256"
             },
             "typeName": {
-              "id": 89,
+              "id": 93,
               "name": "uint",
               "nodeType": "ElementaryTypeName",
-              "src": "805:4:1",
+              "src": "896:4:1",
               "typeDescriptions": {
                 "typeIdentifier": "t_uint256",
                 "typeString": "uint256"
@@ -2602,11 +2910,11 @@
           },
           {
             "constant": false,
-            "id": 92,
+            "id": 96,
             "name": "votersCount",
             "nodeType": "VariableDeclaration",
-            "scope": 207,
-            "src": "869:23:1",
+            "scope": 225,
+            "src": "960:23:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -2614,10 +2922,10 @@
               "typeString": "uint256"
             },
             "typeName": {
-              "id": 91,
+              "id": 95,
               "name": "uint",
               "nodeType": "ElementaryTypeName",
-              "src": "869:4:1",
+              "src": "960:4:1",
               "typeDescriptions": {
                 "typeIdentifier": "t_uint256",
                 "typeString": "uint256"
@@ -2628,9 +2936,9 @@
           },
           {
             "body": {
-              "id": 111,
+              "id": 107,
               "nodeType": "Block",
-              "src": "949:115:1",
+              "src": "1178:528:1",
               "statements": [
                 {
                   "expression": {
@@ -2639,14 +2947,14 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "43616e6469646174652031",
-                        "id": 96,
+                        "id": 100,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
                         "kind": "string",
                         "lValueRequested": false,
                         "nodeType": "Literal",
-                        "src": "966:13:1",
+                        "src": "1198:13:1",
                         "subdenomination": null,
                         "typeDescriptions": {
                           "typeIdentifier": "t_stringliteral_41f9dcbd43e9b33194759b5a51b1df9864cdc2b2138ff106f03091eb79861f0c",
@@ -2662,18 +2970,18 @@
                           "typeString": "literal_string \"Candidate 1\""
                         }
                       ],
-                      "id": 95,
+                      "id": 99,
                       "name": "addCandidate",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 131,
-                      "src": "953:12:1",
+                      "referencedDeclaration": 127,
+                      "src": "1185:12:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_nonpayable$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (string memory)"
                       }
                     },
-                    "id": 97,
+                    "id": 101,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -2681,15 +2989,15 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "953:27:1",
+                    "src": "1185:27:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 98,
+                  "id": 102,
                   "nodeType": "ExpressionStatement",
-                  "src": "953:27:1"
+                  "src": "1185:27:1"
                 },
                 {
                   "expression": {
@@ -2698,14 +3006,14 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "43616e6469646174652032",
-                        "id": 100,
+                        "id": 104,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
                         "kind": "string",
                         "lValueRequested": false,
                         "nodeType": "Literal",
-                        "src": "997:13:1",
+                        "src": "1229:13:1",
                         "subdenomination": null,
                         "typeDescriptions": {
                           "typeIdentifier": "t_stringliteral_f1f17440f69835dafba5c9fd0e4caa6c780807a80f8d1745ec7af1408d6cca4a",
@@ -2721,74 +3029,15 @@
                           "typeString": "literal_string \"Candidate 2\""
                         }
                       ],
-                      "id": 99,
+                      "id": 103,
                       "name": "addCandidate",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 131,
-                      "src": "984:12:1",
+                      "referencedDeclaration": 127,
+                      "src": "1216:12:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_nonpayable$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (string memory)"
-                      }
-                    },
-                    "id": 101,
-                    "isConstant": false,
-                    "isLValue": false,
-                    "isPure": false,
-                    "kind": "functionCall",
-                    "lValueRequested": false,
-                    "names": [],
-                    "nodeType": "FunctionCall",
-                    "src": "984:27:1",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_tuple$__$",
-                      "typeString": "tuple()"
-                    }
-                  },
-                  "id": 102,
-                  "nodeType": "ExpressionStatement",
-                  "src": "984:27:1"
-                },
-                {
-                  "expression": {
-                    "argumentTypes": null,
-                    "arguments": [
-                      {
-                        "argumentTypes": null,
-                        "hexValue": "313030",
-                        "id": 104,
-                        "isConstant": false,
-                        "isLValue": false,
-                        "isPure": true,
-                        "kind": "number",
-                        "lValueRequested": false,
-                        "nodeType": "Literal",
-                        "src": "1025:3:1",
-                        "subdenomination": null,
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_rational_100_by_1",
-                          "typeString": "int_const 100"
-                        },
-                        "value": "100"
-                      }
-                    ],
-                    "expression": {
-                      "argumentTypes": [
-                        {
-                          "typeIdentifier": "t_rational_100_by_1",
-                          "typeString": "int_const 100"
-                        }
-                      ],
-                      "id": 103,
-                      "name": "addVoter",
-                      "nodeType": "Identifier",
-                      "overloadedDeclarations": [],
-                      "referencedDeclaration": 153,
-                      "src": "1016:8:1",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_function_internal_nonpayable$_t_uint256_$returns$__$",
-                        "typeString": "function (uint256)"
                       }
                     },
                     "id": 105,
@@ -2799,7 +3048,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1016:13:1",
+                    "src": "1216:27:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
@@ -2807,71 +3056,12 @@
                   },
                   "id": 106,
                   "nodeType": "ExpressionStatement",
-                  "src": "1016:13:1"
-                },
-                {
-                  "expression": {
-                    "argumentTypes": null,
-                    "arguments": [
-                      {
-                        "argumentTypes": null,
-                        "hexValue": "323030",
-                        "id": 108,
-                        "isConstant": false,
-                        "isLValue": false,
-                        "isPure": true,
-                        "kind": "number",
-                        "lValueRequested": false,
-                        "nodeType": "Literal",
-                        "src": "1056:3:1",
-                        "subdenomination": null,
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_rational_200_by_1",
-                          "typeString": "int_const 200"
-                        },
-                        "value": "200"
-                      }
-                    ],
-                    "expression": {
-                      "argumentTypes": [
-                        {
-                          "typeIdentifier": "t_rational_200_by_1",
-                          "typeString": "int_const 200"
-                        }
-                      ],
-                      "id": 107,
-                      "name": "addVoter",
-                      "nodeType": "Identifier",
-                      "overloadedDeclarations": [],
-                      "referencedDeclaration": 153,
-                      "src": "1047:8:1",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_function_internal_nonpayable$_t_uint256_$returns$__$",
-                        "typeString": "function (uint256)"
-                      }
-                    },
-                    "id": 109,
-                    "isConstant": false,
-                    "isLValue": false,
-                    "isPure": false,
-                    "kind": "functionCall",
-                    "lValueRequested": false,
-                    "names": [],
-                    "nodeType": "FunctionCall",
-                    "src": "1047:13:1",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_tuple$__$",
-                      "typeString": "tuple()"
-                    }
-                  },
-                  "id": 110,
-                  "nodeType": "ExpressionStatement",
-                  "src": "1047:13:1"
+                  "src": "1216:27:1"
                 }
               ]
             },
             "documentation": null,
-            "id": 112,
+            "id": 108,
             "implemented": true,
             "isConstructor": true,
             "isDeclaredConst": false,
@@ -2879,34 +3069,34 @@
             "name": "",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 93,
+              "id": 97,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "939:2:1"
+              "src": "1168:2:1"
             },
             "payable": false,
             "returnParameters": {
-              "id": 94,
+              "id": 98,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "949:0:1"
+              "src": "1178:0:1"
             },
-            "scope": 207,
-            "src": "928:136:1",
+            "scope": 225,
+            "src": "1157:549:1",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
           },
           {
             "body": {
-              "id": 130,
+              "id": 126,
               "nodeType": "Block",
-              "src": "1162:93:1",
+              "src": "1804:93:1",
               "statements": [
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 118,
+                    "id": 114,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -2914,15 +3104,15 @@
                     "nodeType": "UnaryOperation",
                     "operator": "++",
                     "prefix": false,
-                    "src": "1165:17:1",
+                    "src": "1807:17:1",
                     "subExpression": {
                       "argumentTypes": null,
-                      "id": 117,
+                      "id": 113,
                       "name": "candidatesCount",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 90,
-                      "src": "1165:15:1",
+                      "referencedDeclaration": 94,
+                      "src": "1807:15:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
@@ -2933,14 +3123,14 @@
                       "typeString": "uint256"
                     }
                   },
-                  "id": 119,
+                  "id": 115,
                   "nodeType": "ExpressionStatement",
-                  "src": "1165:17:1"
+                  "src": "1807:17:1"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 128,
+                    "id": 124,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -2949,26 +3139,26 @@
                       "argumentTypes": null,
                       "baseExpression": {
                         "argumentTypes": null,
-                        "id": 120,
+                        "id": 116,
                         "name": "candidates",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 80,
-                        "src": "1185:10:1",
+                        "src": "1827:10:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_uint256_$_t_struct$_Candidate_$65_storage_$",
                           "typeString": "mapping(uint256 => struct Election.Candidate storage ref)"
                         }
                       },
-                      "id": 122,
+                      "id": 118,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 121,
+                        "id": 117,
                         "name": "candidatesCount",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 90,
-                        "src": "1196:15:1",
+                        "referencedDeclaration": 94,
+                        "src": "1838:15:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
@@ -2979,7 +3169,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "1185:27:1",
+                      "src": "1827:27:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_struct$_Candidate_$65_storage",
                         "typeString": "struct Election.Candidate storage ref"
@@ -2992,12 +3182,12 @@
                       "arguments": [
                         {
                           "argumentTypes": null,
-                          "id": 124,
+                          "id": 120,
                           "name": "candidatesCount",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 90,
-                          "src": "1225:15:1",
+                          "referencedDeclaration": 94,
+                          "src": "1867:15:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
@@ -3005,12 +3195,12 @@
                         },
                         {
                           "argumentTypes": null,
-                          "id": 125,
+                          "id": 121,
                           "name": "_name",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 114,
-                          "src": "1242:5:1",
+                          "referencedDeclaration": 110,
+                          "src": "1884:5:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_string_memory_ptr",
                             "typeString": "string memory"
@@ -3019,14 +3209,14 @@
                         {
                           "argumentTypes": null,
                           "hexValue": "30",
-                          "id": 126,
+                          "id": 122,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
                           "kind": "number",
                           "lValueRequested": false,
                           "nodeType": "Literal",
-                          "src": "1249:1:1",
+                          "src": "1891:1:1",
                           "subdenomination": null,
                           "typeDescriptions": {
                             "typeIdentifier": "t_rational_0_by_1",
@@ -3050,18 +3240,18 @@
                             "typeString": "int_const 0"
                           }
                         ],
-                        "id": 123,
+                        "id": 119,
                         "name": "Candidate",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 65,
-                        "src": "1215:9:1",
+                        "src": "1857:9:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_type$_t_struct$_Candidate_$65_storage_ptr_$",
                           "typeString": "type(struct Election.Candidate storage pointer)"
                         }
                       },
-                      "id": 127,
+                      "id": 123,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
@@ -3069,26 +3259,26 @@
                       "lValueRequested": false,
                       "names": [],
                       "nodeType": "FunctionCall",
-                      "src": "1215:36:1",
+                      "src": "1857:36:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_struct$_Candidate_$65_memory",
                         "typeString": "struct Election.Candidate memory"
                       }
                     },
-                    "src": "1185:66:1",
+                    "src": "1827:66:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_struct$_Candidate_$65_storage",
                       "typeString": "struct Election.Candidate storage ref"
                     }
                   },
-                  "id": 129,
+                  "id": 125,
                   "nodeType": "ExpressionStatement",
-                  "src": "1185:66:1"
+                  "src": "1827:66:1"
                 }
               ]
             },
             "documentation": null,
-            "id": 131,
+            "id": 127,
             "implemented": true,
             "isConstructor": false,
             "isDeclaredConst": false,
@@ -3096,16 +3286,16 @@
             "name": "addCandidate",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 115,
+              "id": 111,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 114,
+                  "id": 110,
                   "name": "_name",
                   "nodeType": "VariableDeclaration",
-                  "scope": 131,
-                  "src": "1140:12:1",
+                  "scope": 127,
+                  "src": "1782:12:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -3113,10 +3303,10 @@
                     "typeString": "string"
                   },
                   "typeName": {
-                    "id": 113,
+                    "id": 109,
                     "name": "string",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1140:6:1",
+                    "src": "1782:6:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_string_storage_ptr",
                       "typeString": "string"
@@ -3126,335 +3316,26 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "1139:14:1"
+              "src": "1781:14:1"
             },
             "payable": false,
             "returnParameters": {
-              "id": 116,
+              "id": 112,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "1162:0:1"
+              "src": "1804:0:1"
             },
-            "scope": 207,
-            "src": "1118:137:1",
+            "scope": 225,
+            "src": "1760:137:1",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "private"
           },
           {
             "body": {
-              "id": 152,
+              "id": 170,
               "nodeType": "Block",
-              "src": "1343:143:1",
-              "statements": [
-                {
-                  "expression": {
-                    "argumentTypes": null,
-                    "id": 137,
-                    "isConstant": false,
-                    "isLValue": false,
-                    "isPure": false,
-                    "lValueRequested": false,
-                    "nodeType": "UnaryOperation",
-                    "operator": "++",
-                    "prefix": false,
-                    "src": "1346:13:1",
-                    "subExpression": {
-                      "argumentTypes": null,
-                      "id": 136,
-                      "name": "votersCount",
-                      "nodeType": "Identifier",
-                      "overloadedDeclarations": [],
-                      "referencedDeclaration": 92,
-                      "src": "1346:11:1",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_uint256",
-                        "typeString": "uint256"
-                      }
-                    },
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "id": 138,
-                  "nodeType": "ExpressionStatement",
-                  "src": "1346:13:1"
-                },
-                {
-                  "expression": {
-                    "argumentTypes": null,
-                    "id": 150,
-                    "isConstant": false,
-                    "isLValue": false,
-                    "isPure": false,
-                    "lValueRequested": false,
-                    "leftHandSide": {
-                      "argumentTypes": null,
-                      "baseExpression": {
-                        "argumentTypes": null,
-                        "id": 139,
-                        "name": "voters",
-                        "nodeType": "Identifier",
-                        "overloadedDeclarations": [],
-                        "referencedDeclaration": 84,
-                        "src": "1362:6:1",
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
-                          "typeString": "mapping(address => struct Election.Voter storage ref)"
-                        }
-                      },
-                      "id": 142,
-                      "indexExpression": {
-                        "argumentTypes": null,
-                        "expression": {
-                          "argumentTypes": null,
-                          "id": 140,
-                          "name": "msg",
-                          "nodeType": "Identifier",
-                          "overloadedDeclarations": [],
-                          "referencedDeclaration": 222,
-                          "src": "1369:3:1",
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_magic_message",
-                            "typeString": "msg"
-                          }
-                        },
-                        "id": 141,
-                        "isConstant": false,
-                        "isLValue": false,
-                        "isPure": false,
-                        "lValueRequested": false,
-                        "memberName": "sender",
-                        "nodeType": "MemberAccess",
-                        "referencedDeclaration": null,
-                        "src": "1369:10:1",
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_address",
-                          "typeString": "address"
-                        }
-                      },
-                      "isConstant": false,
-                      "isLValue": true,
-                      "isPure": false,
-                      "lValueRequested": true,
-                      "nodeType": "IndexAccess",
-                      "src": "1362:18:1",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_struct$_Voter_$76_storage",
-                        "typeString": "struct Election.Voter storage ref"
-                      }
-                    },
-                    "nodeType": "Assignment",
-                    "operator": "=",
-                    "rightHandSide": {
-                      "argumentTypes": null,
-                      "arguments": [
-                        {
-                          "argumentTypes": null,
-                          "id": 144,
-                          "name": "_nationalID",
-                          "nodeType": "Identifier",
-                          "overloadedDeclarations": [],
-                          "referencedDeclaration": 133,
-                          "src": "1389:11:1",
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_uint256",
-                            "typeString": "uint256"
-                          }
-                        },
-                        {
-                          "argumentTypes": null,
-                          "hexValue": "74727565",
-                          "id": 145,
-                          "isConstant": false,
-                          "isLValue": false,
-                          "isPure": true,
-                          "kind": "bool",
-                          "lValueRequested": false,
-                          "nodeType": "Literal",
-                          "src": "1401:4:1",
-                          "subdenomination": null,
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_bool",
-                            "typeString": "bool"
-                          },
-                          "value": "true"
-                        },
-                        {
-                          "argumentTypes": null,
-                          "hexValue": "66616c7365",
-                          "id": 146,
-                          "isConstant": false,
-                          "isLValue": false,
-                          "isPure": true,
-                          "kind": "bool",
-                          "lValueRequested": false,
-                          "nodeType": "Literal",
-                          "src": "1406:5:1",
-                          "subdenomination": null,
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_bool",
-                            "typeString": "bool"
-                          },
-                          "value": "false"
-                        },
-                        {
-                          "argumentTypes": null,
-                          "hexValue": "30",
-                          "id": 147,
-                          "isConstant": false,
-                          "isLValue": false,
-                          "isPure": true,
-                          "kind": "number",
-                          "lValueRequested": false,
-                          "nodeType": "Literal",
-                          "src": "1412:1:1",
-                          "subdenomination": null,
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_rational_0_by_1",
-                            "typeString": "int_const 0"
-                          },
-                          "value": "0"
-                        },
-                        {
-                          "argumentTypes": null,
-                          "hexValue": "30",
-                          "id": 148,
-                          "isConstant": false,
-                          "isLValue": false,
-                          "isPure": true,
-                          "kind": "number",
-                          "lValueRequested": false,
-                          "nodeType": "Literal",
-                          "src": "1414:1:1",
-                          "subdenomination": null,
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_rational_0_by_1",
-                            "typeString": "int_const 0"
-                          },
-                          "value": "0"
-                        }
-                      ],
-                      "expression": {
-                        "argumentTypes": [
-                          {
-                            "typeIdentifier": "t_uint256",
-                            "typeString": "uint256"
-                          },
-                          {
-                            "typeIdentifier": "t_bool",
-                            "typeString": "bool"
-                          },
-                          {
-                            "typeIdentifier": "t_bool",
-                            "typeString": "bool"
-                          },
-                          {
-                            "typeIdentifier": "t_rational_0_by_1",
-                            "typeString": "int_const 0"
-                          },
-                          {
-                            "typeIdentifier": "t_rational_0_by_1",
-                            "typeString": "int_const 0"
-                          }
-                        ],
-                        "id": 143,
-                        "name": "Voter",
-                        "nodeType": "Identifier",
-                        "overloadedDeclarations": [],
-                        "referencedDeclaration": 76,
-                        "src": "1383:5:1",
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_type$_t_struct$_Voter_$76_storage_ptr_$",
-                          "typeString": "type(struct Election.Voter storage pointer)"
-                        }
-                      },
-                      "id": 149,
-                      "isConstant": false,
-                      "isLValue": false,
-                      "isPure": false,
-                      "kind": "structConstructorCall",
-                      "lValueRequested": false,
-                      "names": [],
-                      "nodeType": "FunctionCall",
-                      "src": "1383:33:1",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_struct$_Voter_$76_memory",
-                        "typeString": "struct Election.Voter memory"
-                      }
-                    },
-                    "src": "1362:54:1",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_struct$_Voter_$76_storage",
-                      "typeString": "struct Election.Voter storage ref"
-                    }
-                  },
-                  "id": 151,
-                  "nodeType": "ExpressionStatement",
-                  "src": "1362:54:1"
-                }
-              ]
-            },
-            "documentation": null,
-            "id": 153,
-            "implemented": true,
-            "isConstructor": false,
-            "isDeclaredConst": false,
-            "modifiers": [],
-            "name": "addVoter",
-            "nodeType": "FunctionDefinition",
-            "parameters": {
-              "id": 134,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 133,
-                  "name": "_nationalID",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 153,
-                  "src": "1318:16:1",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 132,
-                    "name": "uint",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "1318:4:1",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "value": null,
-                  "visibility": "internal"
-                }
-              ],
-              "src": "1317:18:1"
-            },
-            "payable": false,
-            "returnParameters": {
-              "id": 135,
-              "nodeType": "ParameterList",
-              "parameters": [],
-              "src": "1343:0:1"
-            },
-            "scope": 207,
-            "src": "1300:186:1",
-            "stateMutability": "nonpayable",
-            "superFunction": null,
-            "visibility": "public"
-          },
-          {
-            "body": {
-              "id": 205,
-              "nodeType": "Block",
-              "src": "1530:564:1",
+              "src": "1985:351:1",
               "statements": [
                 {
                   "expression": {
@@ -3466,292 +3347,7 @@
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
                         },
-                        "id": 165,
-                        "isConstant": false,
-                        "isLValue": false,
-                        "isPure": false,
-                        "lValueRequested": false,
-                        "leftExpression": {
-                          "argumentTypes": null,
-                          "expression": {
-                            "argumentTypes": null,
-                            "baseExpression": {
-                              "argumentTypes": null,
-                              "id": 159,
-                              "name": "voters",
-                              "nodeType": "Identifier",
-                              "overloadedDeclarations": [],
-                              "referencedDeclaration": 84,
-                              "src": "1586:6:1",
-                              "typeDescriptions": {
-                                "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
-                                "typeString": "mapping(address => struct Election.Voter storage ref)"
-                              }
-                            },
-                            "id": 162,
-                            "indexExpression": {
-                              "argumentTypes": null,
-                              "expression": {
-                                "argumentTypes": null,
-                                "id": 160,
-                                "name": "msg",
-                                "nodeType": "Identifier",
-                                "overloadedDeclarations": [],
-                                "referencedDeclaration": 222,
-                                "src": "1593:3:1",
-                                "typeDescriptions": {
-                                  "typeIdentifier": "t_magic_message",
-                                  "typeString": "msg"
-                                }
-                              },
-                              "id": 161,
-                              "isConstant": false,
-                              "isLValue": false,
-                              "isPure": false,
-                              "lValueRequested": false,
-                              "memberName": "sender",
-                              "nodeType": "MemberAccess",
-                              "referencedDeclaration": null,
-                              "src": "1593:10:1",
-                              "typeDescriptions": {
-                                "typeIdentifier": "t_address",
-                                "typeString": "address"
-                              }
-                            },
-                            "isConstant": false,
-                            "isLValue": true,
-                            "isPure": false,
-                            "lValueRequested": false,
-                            "nodeType": "IndexAccess",
-                            "src": "1586:18:1",
-                            "typeDescriptions": {
-                              "typeIdentifier": "t_struct$_Voter_$76_storage",
-                              "typeString": "struct Election.Voter storage ref"
-                            }
-                          },
-                          "id": 163,
-                          "isConstant": false,
-                          "isLValue": true,
-                          "isPure": false,
-                          "lValueRequested": false,
-                          "memberName": "eligibility",
-                          "nodeType": "MemberAccess",
-                          "referencedDeclaration": 69,
-                          "src": "1586:30:1",
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_bool",
-                            "typeString": "bool"
-                          }
-                        },
-                        "nodeType": "BinaryOperation",
-                        "operator": "==",
-                        "rightExpression": {
-                          "argumentTypes": null,
-                          "hexValue": "74727565",
-                          "id": 164,
-                          "isConstant": false,
-                          "isLValue": false,
-                          "isPure": true,
-                          "kind": "bool",
-                          "lValueRequested": false,
-                          "nodeType": "Literal",
-                          "src": "1620:4:1",
-                          "subdenomination": null,
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_bool",
-                            "typeString": "bool"
-                          },
-                          "value": "true"
-                        },
-                        "src": "1586:38:1",
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_bool",
-                          "typeString": "bool"
-                        }
-                      }
-                    ],
-                    "expression": {
-                      "argumentTypes": [
-                        {
-                          "typeIdentifier": "t_bool",
-                          "typeString": "bool"
-                        }
-                      ],
-                      "id": 158,
-                      "name": "require",
-                      "nodeType": "Identifier",
-                      "overloadedDeclarations": [
-                        225,
-                        226
-                      ],
-                      "referencedDeclaration": 225,
-                      "src": "1578:7:1",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
-                        "typeString": "function (bool) pure"
-                      }
-                    },
-                    "id": 166,
-                    "isConstant": false,
-                    "isLValue": false,
-                    "isPure": false,
-                    "kind": "functionCall",
-                    "lValueRequested": false,
-                    "names": [],
-                    "nodeType": "FunctionCall",
-                    "src": "1578:47:1",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_tuple$__$",
-                      "typeString": "tuple()"
-                    }
-                  },
-                  "id": 167,
-                  "nodeType": "ExpressionStatement",
-                  "src": "1578:47:1"
-                },
-                {
-                  "expression": {
-                    "argumentTypes": null,
-                    "arguments": [
-                      {
-                        "argumentTypes": null,
-                        "id": 174,
-                        "isConstant": false,
-                        "isLValue": false,
-                        "isPure": false,
-                        "lValueRequested": false,
-                        "nodeType": "UnaryOperation",
-                        "operator": "!",
-                        "prefix": true,
-                        "src": "1697:28:1",
-                        "subExpression": {
-                          "argumentTypes": null,
-                          "expression": {
-                            "argumentTypes": null,
-                            "baseExpression": {
-                              "argumentTypes": null,
-                              "id": 169,
-                              "name": "voters",
-                              "nodeType": "Identifier",
-                              "overloadedDeclarations": [],
-                              "referencedDeclaration": 84,
-                              "src": "1698:6:1",
-                              "typeDescriptions": {
-                                "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
-                                "typeString": "mapping(address => struct Election.Voter storage ref)"
-                              }
-                            },
-                            "id": 172,
-                            "indexExpression": {
-                              "argumentTypes": null,
-                              "expression": {
-                                "argumentTypes": null,
-                                "id": 170,
-                                "name": "msg",
-                                "nodeType": "Identifier",
-                                "overloadedDeclarations": [],
-                                "referencedDeclaration": 222,
-                                "src": "1705:3:1",
-                                "typeDescriptions": {
-                                  "typeIdentifier": "t_magic_message",
-                                  "typeString": "msg"
-                                }
-                              },
-                              "id": 171,
-                              "isConstant": false,
-                              "isLValue": false,
-                              "isPure": false,
-                              "lValueRequested": false,
-                              "memberName": "sender",
-                              "nodeType": "MemberAccess",
-                              "referencedDeclaration": null,
-                              "src": "1705:10:1",
-                              "typeDescriptions": {
-                                "typeIdentifier": "t_address",
-                                "typeString": "address"
-                              }
-                            },
-                            "isConstant": false,
-                            "isLValue": true,
-                            "isPure": false,
-                            "lValueRequested": false,
-                            "nodeType": "IndexAccess",
-                            "src": "1698:18:1",
-                            "typeDescriptions": {
-                              "typeIdentifier": "t_struct$_Voter_$76_storage",
-                              "typeString": "struct Election.Voter storage ref"
-                            }
-                          },
-                          "id": 173,
-                          "isConstant": false,
-                          "isLValue": true,
-                          "isPure": false,
-                          "lValueRequested": false,
-                          "memberName": "hasVoted",
-                          "nodeType": "MemberAccess",
-                          "referencedDeclaration": 71,
-                          "src": "1698:27:1",
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_bool",
-                            "typeString": "bool"
-                          }
-                        },
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_bool",
-                          "typeString": "bool"
-                        }
-                      }
-                    ],
-                    "expression": {
-                      "argumentTypes": [
-                        {
-                          "typeIdentifier": "t_bool",
-                          "typeString": "bool"
-                        }
-                      ],
-                      "id": 168,
-                      "name": "require",
-                      "nodeType": "Identifier",
-                      "overloadedDeclarations": [
-                        225,
-                        226
-                      ],
-                      "referencedDeclaration": 225,
-                      "src": "1689:7:1",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
-                        "typeString": "function (bool) pure"
-                      }
-                    },
-                    "id": 175,
-                    "isConstant": false,
-                    "isLValue": false,
-                    "isPure": false,
-                    "kind": "functionCall",
-                    "lValueRequested": false,
-                    "names": [],
-                    "nodeType": "FunctionCall",
-                    "src": "1689:37:1",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_tuple$__$",
-                      "typeString": "tuple()"
-                    }
-                  },
-                  "id": 176,
-                  "nodeType": "ExpressionStatement",
-                  "src": "1689:37:1"
-                },
-                {
-                  "expression": {
-                    "argumentTypes": null,
-                    "arguments": [
-                      {
-                        "argumentTypes": null,
-                        "commonType": {
-                          "typeIdentifier": "t_bool",
-                          "typeString": "bool"
-                        },
-                        "id": 184,
+                        "id": 147,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -3759,48 +3355,107 @@
                         "leftExpression": {
                           "argumentTypes": null,
                           "commonType": {
-                            "typeIdentifier": "t_uint256",
-                            "typeString": "uint256"
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
                           },
-                          "id": 180,
+                          "id": 139,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftExpression": {
                             "argumentTypes": null,
-                            "id": 178,
-                            "name": "_candidateId",
-                            "nodeType": "Identifier",
-                            "overloadedDeclarations": [],
-                            "referencedDeclaration": 155,
-                            "src": "1785:12:1",
+                            "expression": {
+                              "argumentTypes": null,
+                              "baseExpression": {
+                                "argumentTypes": null,
+                                "id": 133,
+                                "name": "voters",
+                                "nodeType": "Identifier",
+                                "overloadedDeclarations": [],
+                                "referencedDeclaration": 84,
+                                "src": "1996:6:1",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+                                  "typeString": "mapping(address => struct Election.Voter storage ref)"
+                                }
+                              },
+                              "id": 136,
+                              "indexExpression": {
+                                "argumentTypes": null,
+                                "expression": {
+                                  "argumentTypes": null,
+                                  "id": 134,
+                                  "name": "msg",
+                                  "nodeType": "Identifier",
+                                  "overloadedDeclarations": [],
+                                  "referencedDeclaration": 240,
+                                  "src": "2003:3:1",
+                                  "typeDescriptions": {
+                                    "typeIdentifier": "t_magic_message",
+                                    "typeString": "msg"
+                                  }
+                                },
+                                "id": 135,
+                                "isConstant": false,
+                                "isLValue": false,
+                                "isPure": false,
+                                "lValueRequested": false,
+                                "memberName": "sender",
+                                "nodeType": "MemberAccess",
+                                "referencedDeclaration": null,
+                                "src": "2003:10:1",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_address",
+                                  "typeString": "address"
+                                }
+                              },
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "nodeType": "IndexAccess",
+                              "src": "1996:18:1",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_struct$_Voter_$76_storage",
+                                "typeString": "struct Election.Voter storage ref"
+                              }
+                            },
+                            "id": 137,
+                            "isConstant": false,
+                            "isLValue": true,
+                            "isPure": false,
+                            "lValueRequested": false,
+                            "memberName": "eligibility",
+                            "nodeType": "MemberAccess",
+                            "referencedDeclaration": 69,
+                            "src": "1996:30:1",
                             "typeDescriptions": {
-                              "typeIdentifier": "t_uint256",
-                              "typeString": "uint256"
+                              "typeIdentifier": "t_bool",
+                              "typeString": "bool"
                             }
                           },
                           "nodeType": "BinaryOperation",
-                          "operator": ">",
+                          "operator": "==",
                           "rightExpression": {
                             "argumentTypes": null,
-                            "hexValue": "30",
-                            "id": 179,
+                            "hexValue": "66616c7365",
+                            "id": 138,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
-                            "kind": "number",
+                            "kind": "bool",
                             "lValueRequested": false,
                             "nodeType": "Literal",
-                            "src": "1800:1:1",
+                            "src": "2030:5:1",
                             "subdenomination": null,
                             "typeDescriptions": {
-                              "typeIdentifier": "t_rational_0_by_1",
-                              "typeString": "int_const 0"
+                              "typeIdentifier": "t_bool",
+                              "typeString": "bool"
                             },
-                            "value": "0"
+                            "value": "false"
                           },
-                          "src": "1785:16:1",
+                          "src": "1996:39:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
@@ -3814,46 +3469,105 @@
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
                           },
-                          "id": 183,
+                          "id": 146,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftExpression": {
                             "argumentTypes": null,
-                            "id": 181,
-                            "name": "_candidateId",
-                            "nodeType": "Identifier",
-                            "overloadedDeclarations": [],
-                            "referencedDeclaration": 155,
-                            "src": "1805:12:1",
+                            "expression": {
+                              "argumentTypes": null,
+                              "baseExpression": {
+                                "argumentTypes": null,
+                                "id": 140,
+                                "name": "voters",
+                                "nodeType": "Identifier",
+                                "overloadedDeclarations": [],
+                                "referencedDeclaration": 84,
+                                "src": "2039:6:1",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+                                  "typeString": "mapping(address => struct Election.Voter storage ref)"
+                                }
+                              },
+                              "id": 143,
+                              "indexExpression": {
+                                "argumentTypes": null,
+                                "expression": {
+                                  "argumentTypes": null,
+                                  "id": 141,
+                                  "name": "msg",
+                                  "nodeType": "Identifier",
+                                  "overloadedDeclarations": [],
+                                  "referencedDeclaration": 240,
+                                  "src": "2046:3:1",
+                                  "typeDescriptions": {
+                                    "typeIdentifier": "t_magic_message",
+                                    "typeString": "msg"
+                                  }
+                                },
+                                "id": 142,
+                                "isConstant": false,
+                                "isLValue": false,
+                                "isPure": false,
+                                "lValueRequested": false,
+                                "memberName": "sender",
+                                "nodeType": "MemberAccess",
+                                "referencedDeclaration": null,
+                                "src": "2046:10:1",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_address",
+                                  "typeString": "address"
+                                }
+                              },
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "nodeType": "IndexAccess",
+                              "src": "2039:18:1",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_struct$_Voter_$76_storage",
+                                "typeString": "struct Election.Voter storage ref"
+                              }
+                            },
+                            "id": 144,
+                            "isConstant": false,
+                            "isLValue": true,
+                            "isPure": false,
+                            "lValueRequested": false,
+                            "memberName": "NID",
+                            "nodeType": "MemberAccess",
+                            "referencedDeclaration": 67,
+                            "src": "2039:22:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
                             }
                           },
                           "nodeType": "BinaryOperation",
-                          "operator": "<=",
+                          "operator": "!=",
                           "rightExpression": {
                             "argumentTypes": null,
-                            "id": 182,
-                            "name": "candidatesCount",
+                            "id": 145,
+                            "name": "_nationalID",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 90,
-                            "src": "1821:15:1",
+                            "referencedDeclaration": 129,
+                            "src": "2065:11:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
                             }
                           },
-                          "src": "1805:31:1",
+                          "src": "2039:37:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
                           }
                         },
-                        "src": "1785:51:1",
+                        "src": "1996:80:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
@@ -3867,21 +3581,21 @@
                           "typeString": "bool"
                         }
                       ],
-                      "id": 177,
+                      "id": 132,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        225,
-                        226
+                        243,
+                        244
                       ],
-                      "referencedDeclaration": 225,
-                      "src": "1777:7:1",
+                      "referencedDeclaration": 243,
+                      "src": "1988:7:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
                         "typeString": "function (bool) pure"
                       }
                     },
-                    "id": 185,
+                    "id": 148,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -3889,130 +3603,20 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1777:60:1",
+                    "src": "1988:89:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 186,
+                  "id": 149,
                   "nodeType": "ExpressionStatement",
-                  "src": "1777:60:1"
+                  "src": "1988:89:1"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 193,
-                    "isConstant": false,
-                    "isLValue": false,
-                    "isPure": false,
-                    "lValueRequested": false,
-                    "leftHandSide": {
-                      "argumentTypes": null,
-                      "expression": {
-                        "argumentTypes": null,
-                        "baseExpression": {
-                          "argumentTypes": null,
-                          "id": 187,
-                          "name": "voters",
-                          "nodeType": "Identifier",
-                          "overloadedDeclarations": [],
-                          "referencedDeclaration": 84,
-                          "src": "1890:6:1",
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
-                            "typeString": "mapping(address => struct Election.Voter storage ref)"
-                          }
-                        },
-                        "id": 190,
-                        "indexExpression": {
-                          "argumentTypes": null,
-                          "expression": {
-                            "argumentTypes": null,
-                            "id": 188,
-                            "name": "msg",
-                            "nodeType": "Identifier",
-                            "overloadedDeclarations": [],
-                            "referencedDeclaration": 222,
-                            "src": "1897:3:1",
-                            "typeDescriptions": {
-                              "typeIdentifier": "t_magic_message",
-                              "typeString": "msg"
-                            }
-                          },
-                          "id": 189,
-                          "isConstant": false,
-                          "isLValue": false,
-                          "isPure": false,
-                          "lValueRequested": false,
-                          "memberName": "sender",
-                          "nodeType": "MemberAccess",
-                          "referencedDeclaration": null,
-                          "src": "1897:10:1",
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_address",
-                            "typeString": "address"
-                          }
-                        },
-                        "isConstant": false,
-                        "isLValue": true,
-                        "isPure": false,
-                        "lValueRequested": false,
-                        "nodeType": "IndexAccess",
-                        "src": "1890:18:1",
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_struct$_Voter_$76_storage",
-                          "typeString": "struct Election.Voter storage ref"
-                        }
-                      },
-                      "id": 191,
-                      "isConstant": false,
-                      "isLValue": true,
-                      "isPure": false,
-                      "lValueRequested": true,
-                      "memberName": "hasVoted",
-                      "nodeType": "MemberAccess",
-                      "referencedDeclaration": 71,
-                      "src": "1890:27:1",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_bool",
-                        "typeString": "bool"
-                      }
-                    },
-                    "nodeType": "Assignment",
-                    "operator": "=",
-                    "rightHandSide": {
-                      "argumentTypes": null,
-                      "hexValue": "74727565",
-                      "id": 192,
-                      "isConstant": false,
-                      "isLValue": false,
-                      "isPure": true,
-                      "kind": "bool",
-                      "lValueRequested": false,
-                      "nodeType": "Literal",
-                      "src": "1920:4:1",
-                      "subdenomination": null,
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_bool",
-                        "typeString": "bool"
-                      },
-                      "value": "true"
-                    },
-                    "src": "1890:34:1",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_bool",
-                      "typeString": "bool"
-                    }
-                  },
-                  "id": 194,
-                  "nodeType": "ExpressionStatement",
-                  "src": "1890:34:1"
-                },
-                {
-                  "expression": {
-                    "argumentTypes": null,
-                    "id": 199,
+                    "id": 151,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -4020,58 +3624,15 @@
                     "nodeType": "UnaryOperation",
                     "operator": "++",
                     "prefix": false,
-                    "src": "1977:36:1",
+                    "src": "2167:13:1",
                     "subExpression": {
                       "argumentTypes": null,
-                      "expression": {
-                        "argumentTypes": null,
-                        "baseExpression": {
-                          "argumentTypes": null,
-                          "id": 195,
-                          "name": "candidates",
-                          "nodeType": "Identifier",
-                          "overloadedDeclarations": [],
-                          "referencedDeclaration": 80,
-                          "src": "1977:10:1",
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_mapping$_t_uint256_$_t_struct$_Candidate_$65_storage_$",
-                            "typeString": "mapping(uint256 => struct Election.Candidate storage ref)"
-                          }
-                        },
-                        "id": 197,
-                        "indexExpression": {
-                          "argumentTypes": null,
-                          "id": 196,
-                          "name": "_candidateId",
-                          "nodeType": "Identifier",
-                          "overloadedDeclarations": [],
-                          "referencedDeclaration": 155,
-                          "src": "1988:12:1",
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_uint256",
-                            "typeString": "uint256"
-                          }
-                        },
-                        "isConstant": false,
-                        "isLValue": true,
-                        "isPure": false,
-                        "lValueRequested": false,
-                        "nodeType": "IndexAccess",
-                        "src": "1977:24:1",
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_struct$_Candidate_$65_storage",
-                          "typeString": "struct Election.Candidate storage ref"
-                        }
-                      },
-                      "id": 198,
-                      "isConstant": false,
-                      "isLValue": true,
-                      "isPure": false,
-                      "lValueRequested": true,
-                      "memberName": "voteCount",
-                      "nodeType": "MemberAccess",
-                      "referencedDeclaration": 64,
-                      "src": "1977:34:1",
+                      "id": 150,
+                      "name": "votersCount",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 96,
+                      "src": "2167:11:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
@@ -4082,9 +3643,222 @@
                       "typeString": "uint256"
                     }
                   },
-                  "id": 200,
+                  "id": 152,
                   "nodeType": "ExpressionStatement",
-                  "src": "1977:36:1"
+                  "src": "2167:13:1"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "id": 164,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "argumentTypes": null,
+                      "baseExpression": {
+                        "argumentTypes": null,
+                        "id": 153,
+                        "name": "voters",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 84,
+                        "src": "2183:6:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+                          "typeString": "mapping(address => struct Election.Voter storage ref)"
+                        }
+                      },
+                      "id": 156,
+                      "indexExpression": {
+                        "argumentTypes": null,
+                        "expression": {
+                          "argumentTypes": null,
+                          "id": 154,
+                          "name": "msg",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 240,
+                          "src": "2190:3:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_magic_message",
+                            "typeString": "msg"
+                          }
+                        },
+                        "id": 155,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "memberName": "sender",
+                        "nodeType": "MemberAccess",
+                        "referencedDeclaration": null,
+                        "src": "2190:10:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      "isConstant": false,
+                      "isLValue": true,
+                      "isPure": false,
+                      "lValueRequested": true,
+                      "nodeType": "IndexAccess",
+                      "src": "2183:18:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_struct$_Voter_$76_storage",
+                        "typeString": "struct Election.Voter storage ref"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "argumentTypes": null,
+                      "arguments": [
+                        {
+                          "argumentTypes": null,
+                          "id": 158,
+                          "name": "_nationalID",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 129,
+                          "src": "2210:11:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        {
+                          "argumentTypes": null,
+                          "hexValue": "74727565",
+                          "id": 159,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "bool",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "2222:4:1",
+                          "subdenomination": null,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          },
+                          "value": "true"
+                        },
+                        {
+                          "argumentTypes": null,
+                          "hexValue": "66616c7365",
+                          "id": 160,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "bool",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "2227:5:1",
+                          "subdenomination": null,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          },
+                          "value": "false"
+                        },
+                        {
+                          "argumentTypes": null,
+                          "hexValue": "30",
+                          "id": 161,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "number",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "2233:1:1",
+                          "subdenomination": null,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_rational_0_by_1",
+                            "typeString": "int_const 0"
+                          },
+                          "value": "0"
+                        },
+                        {
+                          "argumentTypes": null,
+                          "hexValue": "30",
+                          "id": 162,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "number",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "2235:1:1",
+                          "subdenomination": null,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_rational_0_by_1",
+                            "typeString": "int_const 0"
+                          },
+                          "value": "0"
+                        }
+                      ],
+                      "expression": {
+                        "argumentTypes": [
+                          {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          },
+                          {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          },
+                          {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          },
+                          {
+                            "typeIdentifier": "t_rational_0_by_1",
+                            "typeString": "int_const 0"
+                          },
+                          {
+                            "typeIdentifier": "t_rational_0_by_1",
+                            "typeString": "int_const 0"
+                          }
+                        ],
+                        "id": 157,
+                        "name": "Voter",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 76,
+                        "src": "2204:5:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_type$_t_struct$_Voter_$76_storage_ptr_$",
+                          "typeString": "type(struct Election.Voter storage pointer)"
+                        }
+                      },
+                      "id": 163,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "kind": "structConstructorCall",
+                      "lValueRequested": false,
+                      "names": [],
+                      "nodeType": "FunctionCall",
+                      "src": "2204:33:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_struct$_Voter_$76_memory",
+                        "typeString": "struct Election.Voter memory"
+                      }
+                    },
+                    "src": "2183:54:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_struct$_Voter_$76_storage",
+                      "typeString": "struct Election.Voter storage ref"
+                    }
+                  },
+                  "id": 165,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2183:54:1"
                 },
                 {
                   "eventCall": {
@@ -4092,12 +3866,12 @@
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 202,
-                        "name": "_candidateId",
+                        "id": 167,
+                        "name": "_nationalID",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 155,
-                        "src": "2073:12:1",
+                        "referencedDeclaration": 129,
+                        "src": "2320:11:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
@@ -4111,15 +3885,520 @@
                           "typeString": "uint256"
                         }
                       ],
-                      "id": 201,
-                      "name": "votedEvent",
+                      "id": 166,
+                      "name": "newVoter",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 88,
-                      "src": "2062:10:1",
+                      "referencedDeclaration": 92,
+                      "src": "2311:8:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_event_nonpayable$_t_uint256_$returns$__$",
                         "typeString": "function (uint256)"
+                      }
+                    },
+                    "id": 168,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "2311:21:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 169,
+                  "nodeType": "EmitStatement",
+                  "src": "2306:26:1"
+                }
+              ]
+            },
+            "documentation": null,
+            "id": 171,
+            "implemented": true,
+            "isConstructor": false,
+            "isDeclaredConst": false,
+            "modifiers": [],
+            "name": "addVoter",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 130,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 129,
+                  "name": "_nationalID",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 171,
+                  "src": "1960:16:1",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 128,
+                    "name": "uint",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1960:4:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                }
+              ],
+              "src": "1959:18:1"
+            },
+            "payable": false,
+            "returnParameters": {
+              "id": 131,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "1985:0:1"
+            },
+            "scope": 225,
+            "src": "1942:394:1",
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          {
+            "body": {
+              "id": 223,
+              "nodeType": "Block",
+              "src": "2380:564:1",
+              "statements": [
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "arguments": [
+                      {
+                        "argumentTypes": null,
+                        "commonType": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        },
+                        "id": 183,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftExpression": {
+                          "argumentTypes": null,
+                          "expression": {
+                            "argumentTypes": null,
+                            "baseExpression": {
+                              "argumentTypes": null,
+                              "id": 177,
+                              "name": "voters",
+                              "nodeType": "Identifier",
+                              "overloadedDeclarations": [],
+                              "referencedDeclaration": 84,
+                              "src": "2436:6:1",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+                                "typeString": "mapping(address => struct Election.Voter storage ref)"
+                              }
+                            },
+                            "id": 180,
+                            "indexExpression": {
+                              "argumentTypes": null,
+                              "expression": {
+                                "argumentTypes": null,
+                                "id": 178,
+                                "name": "msg",
+                                "nodeType": "Identifier",
+                                "overloadedDeclarations": [],
+                                "referencedDeclaration": 240,
+                                "src": "2443:3:1",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_magic_message",
+                                  "typeString": "msg"
+                                }
+                              },
+                              "id": 179,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "memberName": "sender",
+                              "nodeType": "MemberAccess",
+                              "referencedDeclaration": null,
+                              "src": "2443:10:1",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_address",
+                                "typeString": "address"
+                              }
+                            },
+                            "isConstant": false,
+                            "isLValue": true,
+                            "isPure": false,
+                            "lValueRequested": false,
+                            "nodeType": "IndexAccess",
+                            "src": "2436:18:1",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_struct$_Voter_$76_storage",
+                              "typeString": "struct Election.Voter storage ref"
+                            }
+                          },
+                          "id": 181,
+                          "isConstant": false,
+                          "isLValue": true,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "memberName": "eligibility",
+                          "nodeType": "MemberAccess",
+                          "referencedDeclaration": 69,
+                          "src": "2436:30:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          }
+                        },
+                        "nodeType": "BinaryOperation",
+                        "operator": "==",
+                        "rightExpression": {
+                          "argumentTypes": null,
+                          "hexValue": "74727565",
+                          "id": 182,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "bool",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "2470:4:1",
+                          "subdenomination": null,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          },
+                          "value": "true"
+                        },
+                        "src": "2436:38:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      ],
+                      "id": 176,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        243,
+                        244
+                      ],
+                      "referencedDeclaration": 243,
+                      "src": "2428:7:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
+                        "typeString": "function (bool) pure"
+                      }
+                    },
+                    "id": 184,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "2428:47:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 185,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2428:47:1"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "arguments": [
+                      {
+                        "argumentTypes": null,
+                        "id": 192,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "nodeType": "UnaryOperation",
+                        "operator": "!",
+                        "prefix": true,
+                        "src": "2547:28:1",
+                        "subExpression": {
+                          "argumentTypes": null,
+                          "expression": {
+                            "argumentTypes": null,
+                            "baseExpression": {
+                              "argumentTypes": null,
+                              "id": 187,
+                              "name": "voters",
+                              "nodeType": "Identifier",
+                              "overloadedDeclarations": [],
+                              "referencedDeclaration": 84,
+                              "src": "2548:6:1",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+                                "typeString": "mapping(address => struct Election.Voter storage ref)"
+                              }
+                            },
+                            "id": 190,
+                            "indexExpression": {
+                              "argumentTypes": null,
+                              "expression": {
+                                "argumentTypes": null,
+                                "id": 188,
+                                "name": "msg",
+                                "nodeType": "Identifier",
+                                "overloadedDeclarations": [],
+                                "referencedDeclaration": 240,
+                                "src": "2555:3:1",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_magic_message",
+                                  "typeString": "msg"
+                                }
+                              },
+                              "id": 189,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "memberName": "sender",
+                              "nodeType": "MemberAccess",
+                              "referencedDeclaration": null,
+                              "src": "2555:10:1",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_address",
+                                "typeString": "address"
+                              }
+                            },
+                            "isConstant": false,
+                            "isLValue": true,
+                            "isPure": false,
+                            "lValueRequested": false,
+                            "nodeType": "IndexAccess",
+                            "src": "2548:18:1",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_struct$_Voter_$76_storage",
+                              "typeString": "struct Election.Voter storage ref"
+                            }
+                          },
+                          "id": 191,
+                          "isConstant": false,
+                          "isLValue": true,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "memberName": "hasVoted",
+                          "nodeType": "MemberAccess",
+                          "referencedDeclaration": 71,
+                          "src": "2548:27:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          }
+                        },
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      ],
+                      "id": 186,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        243,
+                        244
+                      ],
+                      "referencedDeclaration": 243,
+                      "src": "2539:7:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
+                        "typeString": "function (bool) pure"
+                      }
+                    },
+                    "id": 193,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "2539:37:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 194,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2539:37:1"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "arguments": [
+                      {
+                        "argumentTypes": null,
+                        "commonType": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        },
+                        "id": 202,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftExpression": {
+                          "argumentTypes": null,
+                          "commonType": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          },
+                          "id": 198,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "leftExpression": {
+                            "argumentTypes": null,
+                            "id": 196,
+                            "name": "_candidateId",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 173,
+                            "src": "2635:12:1",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_uint256",
+                              "typeString": "uint256"
+                            }
+                          },
+                          "nodeType": "BinaryOperation",
+                          "operator": ">",
+                          "rightExpression": {
+                            "argumentTypes": null,
+                            "hexValue": "30",
+                            "id": 197,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "kind": "number",
+                            "lValueRequested": false,
+                            "nodeType": "Literal",
+                            "src": "2650:1:1",
+                            "subdenomination": null,
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_rational_0_by_1",
+                              "typeString": "int_const 0"
+                            },
+                            "value": "0"
+                          },
+                          "src": "2635:16:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          }
+                        },
+                        "nodeType": "BinaryOperation",
+                        "operator": "&&",
+                        "rightExpression": {
+                          "argumentTypes": null,
+                          "commonType": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          },
+                          "id": 201,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "leftExpression": {
+                            "argumentTypes": null,
+                            "id": 199,
+                            "name": "_candidateId",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 173,
+                            "src": "2655:12:1",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_uint256",
+                              "typeString": "uint256"
+                            }
+                          },
+                          "nodeType": "BinaryOperation",
+                          "operator": "<=",
+                          "rightExpression": {
+                            "argumentTypes": null,
+                            "id": 200,
+                            "name": "candidatesCount",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 94,
+                            "src": "2671:15:1",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_uint256",
+                              "typeString": "uint256"
+                            }
+                          },
+                          "src": "2655:31:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          }
+                        },
+                        "src": "2635:51:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      ],
+                      "id": 195,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        243,
+                        244
+                      ],
+                      "referencedDeclaration": 243,
+                      "src": "2627:7:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
+                        "typeString": "function (bool) pure"
                       }
                     },
                     "id": 203,
@@ -4130,20 +4409,261 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "2062:24:1",
+                    "src": "2627:60:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
                   "id": 204,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2627:60:1"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "id": 211,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "argumentTypes": null,
+                      "expression": {
+                        "argumentTypes": null,
+                        "baseExpression": {
+                          "argumentTypes": null,
+                          "id": 205,
+                          "name": "voters",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 84,
+                          "src": "2740:6:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+                            "typeString": "mapping(address => struct Election.Voter storage ref)"
+                          }
+                        },
+                        "id": 208,
+                        "indexExpression": {
+                          "argumentTypes": null,
+                          "expression": {
+                            "argumentTypes": null,
+                            "id": 206,
+                            "name": "msg",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 240,
+                            "src": "2747:3:1",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_magic_message",
+                              "typeString": "msg"
+                            }
+                          },
+                          "id": 207,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "memberName": "sender",
+                          "nodeType": "MemberAccess",
+                          "referencedDeclaration": null,
+                          "src": "2747:10:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          }
+                        },
+                        "isConstant": false,
+                        "isLValue": true,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "nodeType": "IndexAccess",
+                        "src": "2740:18:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_struct$_Voter_$76_storage",
+                          "typeString": "struct Election.Voter storage ref"
+                        }
+                      },
+                      "id": 209,
+                      "isConstant": false,
+                      "isLValue": true,
+                      "isPure": false,
+                      "lValueRequested": true,
+                      "memberName": "hasVoted",
+                      "nodeType": "MemberAccess",
+                      "referencedDeclaration": 71,
+                      "src": "2740:27:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "argumentTypes": null,
+                      "hexValue": "74727565",
+                      "id": 210,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "kind": "bool",
+                      "lValueRequested": false,
+                      "nodeType": "Literal",
+                      "src": "2770:4:1",
+                      "subdenomination": null,
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      },
+                      "value": "true"
+                    },
+                    "src": "2740:34:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bool",
+                      "typeString": "bool"
+                    }
+                  },
+                  "id": 212,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2740:34:1"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "id": 217,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "nodeType": "UnaryOperation",
+                    "operator": "++",
+                    "prefix": false,
+                    "src": "2827:36:1",
+                    "subExpression": {
+                      "argumentTypes": null,
+                      "expression": {
+                        "argumentTypes": null,
+                        "baseExpression": {
+                          "argumentTypes": null,
+                          "id": 213,
+                          "name": "candidates",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 80,
+                          "src": "2827:10:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_mapping$_t_uint256_$_t_struct$_Candidate_$65_storage_$",
+                            "typeString": "mapping(uint256 => struct Election.Candidate storage ref)"
+                          }
+                        },
+                        "id": 215,
+                        "indexExpression": {
+                          "argumentTypes": null,
+                          "id": 214,
+                          "name": "_candidateId",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 173,
+                          "src": "2838:12:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        "isConstant": false,
+                        "isLValue": true,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "nodeType": "IndexAccess",
+                        "src": "2827:24:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_struct$_Candidate_$65_storage",
+                          "typeString": "struct Election.Candidate storage ref"
+                        }
+                      },
+                      "id": 216,
+                      "isConstant": false,
+                      "isLValue": true,
+                      "isPure": false,
+                      "lValueRequested": true,
+                      "memberName": "voteCount",
+                      "nodeType": "MemberAccess",
+                      "referencedDeclaration": 64,
+                      "src": "2827:34:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "id": 218,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2827:36:1"
+                },
+                {
+                  "eventCall": {
+                    "argumentTypes": null,
+                    "arguments": [
+                      {
+                        "argumentTypes": null,
+                        "id": 220,
+                        "name": "_candidateId",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 173,
+                        "src": "2923:12:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      ],
+                      "id": 219,
+                      "name": "votedEvent",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 88,
+                      "src": "2912:10:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_event_nonpayable$_t_uint256_$returns$__$",
+                        "typeString": "function (uint256)"
+                      }
+                    },
+                    "id": 221,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "2912:24:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 222,
                   "nodeType": "EmitStatement",
-                  "src": "2057:29:1"
+                  "src": "2907:29:1"
                 }
               ]
             },
             "documentation": null,
-            "id": 206,
+            "id": 224,
             "implemented": true,
             "isConstructor": false,
             "isDeclaredConst": false,
@@ -4151,16 +4671,16 @@
             "name": "vote",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 156,
+              "id": 174,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 155,
+                  "id": 173,
                   "name": "_candidateId",
                   "nodeType": "VariableDeclaration",
-                  "scope": 206,
-                  "src": "1504:17:1",
+                  "scope": 224,
+                  "src": "2354:17:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -4168,10 +4688,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 154,
+                    "id": 172,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1504:4:1",
+                    "src": "2354:4:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -4181,27 +4701,27 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "1503:19:1"
+              "src": "2353:19:1"
             },
             "payable": false,
             "returnParameters": {
-              "id": 157,
+              "id": 175,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "1530:0:1"
+              "src": "2380:0:1"
             },
-            "scope": 207,
-            "src": "1490:604:1",
+            "scope": 225,
+            "src": "2340:604:1",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
           }
         ],
-        "scope": 208,
-        "src": "27:2070:1"
+        "scope": 226,
+        "src": "28:2919:1"
       }
     ],
-    "src": "0:2099:1"
+    "src": "0:2949:1"
   },
   "compiler": {
     "name": "solc",
@@ -4222,15 +4742,28 @@
           "name": "votedEvent",
           "type": "event",
           "signature": "0xfff3c900d938d21d0990d786e819f29b8d05c1ef587b462b939609625b684b16"
+        },
+        "0xdf46bb731dd3f934fde468a9d86e0ccf9197f737d59f9df5e4d75f380a44e2d9": {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "name": "_nationalID",
+              "type": "uint256"
+            }
+          ],
+          "name": "newVoter",
+          "type": "event",
+          "signature": "0xdf46bb731dd3f934fde468a9d86e0ccf9197f737d59f9df5e4d75f380a44e2d9"
         }
       },
       "links": {},
-      "address": "0x1663C43c772e9d12Bee23e988225d386ee3b965E",
-      "transactionHash": "0xa299a0f8b279e37320ed0393e051ae4ea18dbf0c7e03a2de588b5cc19ea41a73"
+      "address": "0x23E8c302F28aceb4BbC15C184dBf1F1Ccce7da4d",
+      "transactionHash": "0xf0a6ee43388a1ed487428a8d4ff1076ad00facfcb35431b19e3d4c6f483e26a9"
     }
   },
   "schemaVersion": "3.0.22",
-  "updatedAt": "2020-08-06T14:54:56.112Z",
+  "updatedAt": "2020-08-07T21:10:55.882Z",
   "networkType": "ethereum",
   "devdoc": {
     "methods": {}

--- a/build/contracts/Election.json
+++ b/build/contracts/Election.json
@@ -150,12 +150,12 @@
       "type": "function"
     }
   ],
-  "metadata": "{\"compiler\":{\"version\":\"0.4.23+commit.124ca40d\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"constant\":false,\"inputs\":[{\"name\":\"_candidateId\",\"type\":\"uint256\"}],\"name\":\"vote\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"candidatesCount\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"candidates\",\"outputs\":[{\"name\":\"id\",\"type\":\"uint256\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"voteCount\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"votersCount\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"address\"}],\"name\":\"voters\",\"outputs\":[{\"name\":\"NID\",\"type\":\"uint256\"},{\"name\":\"eligibility\",\"type\":\"bool\"},{\"name\":\"hasVoted\",\"type\":\"bool\"},{\"name\":\"blindedVote\",\"type\":\"uint256\"},{\"name\":\"signedBlindedVote\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_nationalID\",\"type\":\"uint256\"}],\"name\":\"addVoter\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"_candidateId\",\"type\":\"uint256\"}],\"name\":\"votedEvent\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"_nationalID\",\"type\":\"uint256\"}],\"name\":\"newVoter\",\"type\":\"event\"}],\"devdoc\":{\"methods\":{}},\"userdoc\":{\"methods\":{}}},\"settings\":{\"compilationTarget\":{\"/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/election.sol\":\"Election\"},\"evmVersion\":\"byzantium\",\"libraries\":{},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/election.sol\":{\"keccak256\":\"0x6e4b1d0b80229447425a479cf4cfd5ad97d286da79bed256fbc4d5cc2c5cabb1\",\"urls\":[\"bzzr://7110cccbebb33c935e7402b9eb774fc715d48378ce0fb751f65b538ab8069533\"]}},\"version\":1}",
-  "bytecode": "0x608060405234801561001057600080fd5b5061005e6040805190810160405280600b81526020017f43616e64696461746520310000000000000000000000000000000000000000008152506100b0640100000000026401000000009004565b6100ab6040805190810160405280600b81526020017f43616e64696461746520320000000000000000000000000000000000000000008152506100b0640100000000026401000000009004565b6101d1565b60026000815480929190600101919050555060606040519081016040528060025481526020018281526020016000815250600080600254815260200190815260200160002060008201518160000155602082015181600101908051906020019061011b92919061012c565b506040820151816002015590505050565b828054600181600116156101000203166002900490600052602060002090601f016020900481019282601f1061016d57805160ff191683800117855561019b565b8280016001018555821561019b579182015b8281111561019a57825182559160200191906001019061017f565b5b5090506101a891906101ac565b5090565b6101ce91905b808211156101ca5760008160009055506001016101b2565b5090565b90565b6106f2806101e06000396000f300608060405260043610610078576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630121b93f1461007d5780632d35a8a2146100aa5780633477ee2e146100d557806398c0793814610189578063a3ec138d146101b4578063d8f7a0bb1461022f575b600080fd5b34801561008957600080fd5b506100a86004803603810190808035906020019092919050505061025c565b005b3480156100b657600080fd5b506100bf6103e6565b6040518082815260200191505060405180910390f35b3480156100e157600080fd5b50610100600480360381019080803590602001909291905050506103ec565b6040518084815260200180602001838152602001828103825284818151815260200191508051906020019080838360005b8381101561014c578082015181840152602081019050610131565b50505050905090810190601f1680156101795780820380516001836020036101000a031916815260200191505b5094505050505060405180910390f35b34801561019557600080fd5b5061019e6104ae565b6040518082815260200191505060405180910390f35b3480156101c057600080fd5b506101f5600480360381019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506104b4565b6040518086815260200185151515158152602001841515151581526020018381526020018281526020019550505050505060405180910390f35b34801561023b57600080fd5b5061025a60048036038101908080359060200190929190505050610504565b005b60011515600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160009054906101000a900460ff1615151415156102be57600080fd5b600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160019054906101000a900460ff1615151561031a57600080fd5b60008111801561032c57506002548111155b151561033757600080fd5b60018060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160016101000a81548160ff02191690831515021790555060008082815260200190815260200160002060020160008154809291906001019190505550807ffff3c900d938d21d0990d786e819f29b8d05c1ef587b462b939609625b684b1660405160405180910390a250565b60025481565b6000602052806000526040600020600091509050806000015490806001018054600181600116156101000203166002900480601f01602080910402602001604051908101604052809291908181526020018280546001816001161561010002031660029004801561049e5780601f106104735761010080835404028352916020019161049e565b820191906000526020600020905b81548152906001019060200180831161048157829003601f168201915b5050505050908060020154905083565b60035481565b60016020528060005260406000206000915090508060000154908060010160009054906101000a900460ff16908060010160019054906101000a900460ff16908060020154908060030154905085565b60001515600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160009054906101000a900460ff1615151480156105a9575080600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000015414155b15156105b457600080fd5b60036000815480929190600101919050555060a060405190810160405280828152602001600115158152602001600015158152602001600081526020016000815250600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000820151816000015560208201518160010160006101000a81548160ff02191690831515021790555060408201518160010160016101000a81548160ff0219169083151502179055506060820151816002015560808201518160030155905050807fdf46bb731dd3f934fde468a9d86e0ccf9197f737d59f9df5e4d75f380a44e2d960405160405180910390a2505600a165627a7a72305820ddee80aad71be8e311aac956f622f06e898360d5ec255b579199462c1e483adf0029",
-  "deployedBytecode": "0x608060405260043610610078576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630121b93f1461007d5780632d35a8a2146100aa5780633477ee2e146100d557806398c0793814610189578063a3ec138d146101b4578063d8f7a0bb1461022f575b600080fd5b34801561008957600080fd5b506100a86004803603810190808035906020019092919050505061025c565b005b3480156100b657600080fd5b506100bf6103e6565b6040518082815260200191505060405180910390f35b3480156100e157600080fd5b50610100600480360381019080803590602001909291905050506103ec565b6040518084815260200180602001838152602001828103825284818151815260200191508051906020019080838360005b8381101561014c578082015181840152602081019050610131565b50505050905090810190601f1680156101795780820380516001836020036101000a031916815260200191505b5094505050505060405180910390f35b34801561019557600080fd5b5061019e6104ae565b6040518082815260200191505060405180910390f35b3480156101c057600080fd5b506101f5600480360381019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506104b4565b6040518086815260200185151515158152602001841515151581526020018381526020018281526020019550505050505060405180910390f35b34801561023b57600080fd5b5061025a60048036038101908080359060200190929190505050610504565b005b60011515600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160009054906101000a900460ff1615151415156102be57600080fd5b600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160019054906101000a900460ff1615151561031a57600080fd5b60008111801561032c57506002548111155b151561033757600080fd5b60018060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160016101000a81548160ff02191690831515021790555060008082815260200190815260200160002060020160008154809291906001019190505550807ffff3c900d938d21d0990d786e819f29b8d05c1ef587b462b939609625b684b1660405160405180910390a250565b60025481565b6000602052806000526040600020600091509050806000015490806001018054600181600116156101000203166002900480601f01602080910402602001604051908101604052809291908181526020018280546001816001161561010002031660029004801561049e5780601f106104735761010080835404028352916020019161049e565b820191906000526020600020905b81548152906001019060200180831161048157829003601f168201915b5050505050908060020154905083565b60035481565b60016020528060005260406000206000915090508060000154908060010160009054906101000a900460ff16908060010160019054906101000a900460ff16908060020154908060030154905085565b60001515600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160009054906101000a900460ff1615151480156105a9575080600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000015414155b15156105b457600080fd5b60036000815480929190600101919050555060a060405190810160405280828152602001600115158152602001600015158152602001600081526020016000815250600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000820151816000015560208201518160010160006101000a81548160ff02191690831515021790555060408201518160010160016101000a81548160ff0219169083151502179055506060820151816002015560808201518160030155905050807fdf46bb731dd3f934fde468a9d86e0ccf9197f737d59f9df5e4d75f380a44e2d960405160405180910390a2505600a165627a7a72305820ddee80aad71be8e311aac956f622f06e898360d5ec255b579199462c1e483adf0029",
-  "sourceMap": "28:2919:1:-;;;1157:549;8:9:-1;5:2;;;30:1;27;20:12;5:2;1157:549:1;1185:27;;;;;;;;;;;;;;;;;;;:12;;;:27;;;:::i;:::-;1216;;;;;;;;;;;;;;;;;;;:12;;;:27;;;:::i;:::-;28:2919;;1760:137;1807:15;;:17;;;;;;;;;;;;;1857:36;;;;;;;;;1867:15;;1857:36;;;;1884:5;1857:36;;;;1891:1;1857:36;;;1827:10;:27;1838:15;;1827:27;;;;;;;;;;;:66;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;1760:137;:::o;28:2919::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;:::o;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;:::o;:::-;;;;;;;",
-  "deployedSourceMap": "28:2919:1:-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;2340:604;;8:9:-1;5:2;;;30:1;27;20:12;5:2;2340:604:1;;;;;;;;;;;;;;;;;;;;;;;;;;896:27;;8:9:-1;5:2;;;30:1;27;20:12;5:2;896:27:1;;;;;;;;;;;;;;;;;;;;;;;558:44;;8:9:-1;5:2;;;30:1;27;20:12;5:2;558:44:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;23:1:-1;8:100;33:3;30:1;27:10;8:100;;;99:1;94:3;90:11;84:18;80:1;75:3;71:11;64:39;52:2;49:1;45:10;40:15;;8:100;;;12:14;558:44:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;960:23;;8:9:-1;5:2;;;30:1;27;20:12;5:2;960:23:1;;;;;;;;;;;;;;;;;;;;;;;642:39;;8:9:-1;5:2;;;30:1;27;20:12;5:2;642:39:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1942:394;;8:9:-1;5:2;;;30:1;27;20:12;5:2;1942:394:1;;;;;;;;;;;;;;;;;;;;;;;;;;2340:604;2470:4;2436:38;;:6;:18;2443:10;2436:18;;;;;;;;;;;;;;;:30;;;;;;;;;;;;:38;;;2428:47;;;;;;;;2548:6;:18;2555:10;2548:18;;;;;;;;;;;;;;;:27;;;;;;;;;;;;2547:28;2539:37;;;;;;;;2650:1;2635:12;:16;:51;;;;;2671:15;;2655:12;:31;;2635:51;2627:60;;;;;;;;2770:4;2740:6;:18;2747:10;2740:18;;;;;;;;;;;;;;;:27;;;:34;;;;;;;;;;;;;;;;;;2827:10;:24;2838:12;2827:24;;;;;;;;;;;:34;;;:36;;;;;;;;;;;;;2923:12;2912:24;;;;;;;;;;2340:604;:::o;896:27::-;;;;:::o;558:44::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::o;960:23::-;;;;:::o;642:39::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::o;1942:394::-;2030:5;1996:39;;:6;:18;2003:10;1996:18;;;;;;;;;;;;;;;:30;;;;;;;;;;;;:39;;;:80;;;;;2065:11;2039:6;:18;2046:10;2039:18;;;;;;;;;;;;;;;:22;;;:37;;1996:80;1988:89;;;;;;;;2167:11;;:13;;;;;;;;;;;;;2204:33;;;;;;;;;2210:11;2204:33;;;;2222:4;2204:33;;;;;;2227:5;2204:33;;;;;;2233:1;2204:33;;;;2235:1;2204:33;;;2183:6;:18;2190:10;2183:18;;;;;;;;;;;;;;;:54;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;2320:11;2311:21;;;;;;;;;;1942:394;:::o",
-  "source": "pragma solidity ^0.4.23;\r\n\r\ncontract Election {\r\n// Model a Candidate\r\n struct Candidate {\r\n\tuint id;\r\n\tstring name;\r\n\tuint voteCount;\r\n}\r\n//Modle a voter\r\nstruct Voter {\r\n  uint NID;     // govt issued national identification number of candidate\r\n  bool eligibility;      // stores the valid list of voters during registration\r\n  bool hasVoted;    // updates when vote is successfully casted on blockchain\r\n  uint blindedVote;    // stores each voter's hashed vote\r\n  uint signedBlindedVote;  // blind signature of casted vote\r\n}\r\n// Read/write candidates\r\nmapping(uint => Candidate) public candidates;\r\n\r\n// Store accounts that have voted\r\nmapping(address => Voter) public voters;\r\n\r\n// event for logging successful votes\r\nevent votedEvent(\r\n  uint indexed _candidateId\r\n  );\r\n\r\n// event for logging successful votes\r\nevent newVoter(\r\n  uint indexed _nationalID\r\n);\r\n// Store Candidates Count\r\nuint public candidatesCount;   // counter cache for candidates\r\nuint public votersCount;    // counter cache for voters\r\n\r\n// DEMO Voter accounts\r\n// voter-1 : 0x793ab88bDa1029b65737D71a2402f18D15C09AC8\r\n// voter-2 : 0xD8b33BF7080dF17888690fa6092300DEd6C19fC8\r\nconstructor() public {\r\n\r\n  addCandidate(\"Candidate 1\");\r\n\taddCandidate(\"Candidate 2\");\r\n//  addVoter(100);   addvoter() function is not used in constructor statement because it invokes require(), but the contract hasn't beem created before constructor call\r\n//  addVoter(200);\r\n  /* votersCount++;\r\n  voters[0x793ab88bDa1029b65737D71a2402f18D15C09AC8] = Voter(100,true,false,0,0); // first demo voter NID - 100\r\n  votersCount++;\r\n  voters[0x793ab88bDa1029b65737D71a2402f18D15C09AC8] = Voter(200,true,false,0,0); // second demo voter NID - 200 */\r\n}\r\n\r\n// candidates are pre populated for the election\r\nfunction addCandidate(string _name) private {\r\ncandidatesCount++;\r\ncandidates[candidatesCount] = Candidate(candidatesCount, _name, 0);\r\n}\r\n\r\n// anyone can register for the election\r\nfunction addVoter(uint _nationalID) public {\r\nrequire(voters[msg.sender].eligibility == false && voters[msg.sender].NID != _nationalID);  //checks if voter has registered before with same NID / Disallows Double Registration\r\nvotersCount++;\r\nvoters[msg.sender] = Voter(_nationalID,true,false,0,0);   // (NID, eligibility, hasVoted, BlindedVote, signedBlindedVote)\r\nemit newVoter(_nationalID);\r\n}\r\n\r\nfunction vote(uint _candidateId) public {\r\n\r\n        // registered voter check\r\n        require(voters[msg.sender].eligibility == true);\r\n\r\n        // require that they haven't voted before\r\n        require(!voters[msg.sender].hasVoted);\r\n\r\n        // require a valid candidate\r\n        require(_candidateId > 0 && _candidateId <= candidatesCount);\r\n\r\n        // record that voter has voted\r\n        voters[msg.sender].hasVoted = true;\r\n\r\n        // update candidate vote Count\r\n        candidates[_candidateId].voteCount++;\r\n\r\n        //trigger voted event\r\n        emit votedEvent(_candidateId);\r\n    }\r\n}\r\n",
+  "metadata": "{\"compiler\":{\"version\":\"0.4.23+commit.124ca40d\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"constant\":false,\"inputs\":[{\"name\":\"_candidateId\",\"type\":\"uint256\"}],\"name\":\"vote\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"candidatesCount\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"candidates\",\"outputs\":[{\"name\":\"id\",\"type\":\"uint256\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"voteCount\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"votersCount\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"address\"}],\"name\":\"voters\",\"outputs\":[{\"name\":\"NID\",\"type\":\"uint256\"},{\"name\":\"eligibility\",\"type\":\"bool\"},{\"name\":\"hasVoted\",\"type\":\"bool\"},{\"name\":\"blindedVote\",\"type\":\"uint256\"},{\"name\":\"signedBlindedVote\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_nationalID\",\"type\":\"uint256\"}],\"name\":\"addVoter\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"_candidateId\",\"type\":\"uint256\"}],\"name\":\"votedEvent\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"_nationalID\",\"type\":\"uint256\"}],\"name\":\"newVoter\",\"type\":\"event\"}],\"devdoc\":{\"methods\":{}},\"userdoc\":{\"methods\":{}}},\"settings\":{\"compilationTarget\":{\"/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/election.sol\":\"Election\"},\"evmVersion\":\"byzantium\",\"libraries\":{},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/election.sol\":{\"keccak256\":\"0x6d7208649482d64f3472c8dcadf63b42969eca6a1b8db32cfcf302da7520007b\",\"urls\":[\"bzzr://da2db6c3c609f454d3dff72b863c747a11ccdc23a32550258c7c54cf30a1df3a\"]}},\"version\":1}",
+  "bytecode": "0x608060405234801561001057600080fd5b5061005e6040805190810160405280600b81526020017f43616e64696461746520310000000000000000000000000000000000000000008152506100b0640100000000026401000000009004565b6100ab6040805190810160405280600b81526020017f43616e64696461746520320000000000000000000000000000000000000000008152506100b0640100000000026401000000009004565b6101d1565b60026000815480929190600101919050555060606040519081016040528060025481526020018281526020016000815250600080600254815260200190815260200160002060008201518160000155602082015181600101908051906020019061011b92919061012c565b506040820151816002015590505050565b828054600181600116156101000203166002900490600052602060002090601f016020900481019282601f1061016d57805160ff191683800117855561019b565b8280016001018555821561019b579182015b8281111561019a57825182559160200191906001019061017f565b5b5090506101a891906101ac565b5090565b6101ce91905b808211156101ca5760008160009055506001016101b2565b5090565b90565b6106f2806101e06000396000f300608060405260043610610078576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630121b93f1461007d5780632d35a8a2146100aa5780633477ee2e146100d557806398c0793814610189578063a3ec138d146101b4578063d8f7a0bb1461022f575b600080fd5b34801561008957600080fd5b506100a86004803603810190808035906020019092919050505061025c565b005b3480156100b657600080fd5b506100bf6103e6565b6040518082815260200191505060405180910390f35b3480156100e157600080fd5b50610100600480360381019080803590602001909291905050506103ec565b6040518084815260200180602001838152602001828103825284818151815260200191508051906020019080838360005b8381101561014c578082015181840152602081019050610131565b50505050905090810190601f1680156101795780820380516001836020036101000a031916815260200191505b5094505050505060405180910390f35b34801561019557600080fd5b5061019e6104ae565b6040518082815260200191505060405180910390f35b3480156101c057600080fd5b506101f5600480360381019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506104b4565b6040518086815260200185151515158152602001841515151581526020018381526020018281526020019550505050505060405180910390f35b34801561023b57600080fd5b5061025a60048036038101908080359060200190929190505050610504565b005b60011515600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160009054906101000a900460ff1615151415156102be57600080fd5b600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160019054906101000a900460ff1615151561031a57600080fd5b60008111801561032c57506002548111155b151561033757600080fd5b60018060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160016101000a81548160ff02191690831515021790555060008082815260200190815260200160002060020160008154809291906001019190505550807ffff3c900d938d21d0990d786e819f29b8d05c1ef587b462b939609625b684b1660405160405180910390a250565b60025481565b6000602052806000526040600020600091509050806000015490806001018054600181600116156101000203166002900480601f01602080910402602001604051908101604052809291908181526020018280546001816001161561010002031660029004801561049e5780601f106104735761010080835404028352916020019161049e565b820191906000526020600020905b81548152906001019060200180831161048157829003601f168201915b5050505050908060020154905083565b60035481565b60016020528060005260406000206000915090508060000154908060010160009054906101000a900460ff16908060010160019054906101000a900460ff16908060020154908060030154905085565b60001515600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160009054906101000a900460ff1615151480156105a9575080600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000015414155b15156105b457600080fd5b60036000815480929190600101919050555060a060405190810160405280828152602001600115158152602001600015158152602001600081526020016000815250600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000820151816000015560208201518160010160006101000a81548160ff02191690831515021790555060408201518160010160016101000a81548160ff0219169083151502179055506060820151816002015560808201518160030155905050807fdf46bb731dd3f934fde468a9d86e0ccf9197f737d59f9df5e4d75f380a44e2d960405160405180910390a2505600a165627a7a723058202c4a17e625db51d72d0780b3bb0c53dceb2af686d07f50d1f42ca602f9c2347c0029",
+  "deployedBytecode": "0x608060405260043610610078576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630121b93f1461007d5780632d35a8a2146100aa5780633477ee2e146100d557806398c0793814610189578063a3ec138d146101b4578063d8f7a0bb1461022f575b600080fd5b34801561008957600080fd5b506100a86004803603810190808035906020019092919050505061025c565b005b3480156100b657600080fd5b506100bf6103e6565b6040518082815260200191505060405180910390f35b3480156100e157600080fd5b50610100600480360381019080803590602001909291905050506103ec565b6040518084815260200180602001838152602001828103825284818151815260200191508051906020019080838360005b8381101561014c578082015181840152602081019050610131565b50505050905090810190601f1680156101795780820380516001836020036101000a031916815260200191505b5094505050505060405180910390f35b34801561019557600080fd5b5061019e6104ae565b6040518082815260200191505060405180910390f35b3480156101c057600080fd5b506101f5600480360381019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506104b4565b6040518086815260200185151515158152602001841515151581526020018381526020018281526020019550505050505060405180910390f35b34801561023b57600080fd5b5061025a60048036038101908080359060200190929190505050610504565b005b60011515600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160009054906101000a900460ff1615151415156102be57600080fd5b600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160019054906101000a900460ff1615151561031a57600080fd5b60008111801561032c57506002548111155b151561033757600080fd5b60018060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160016101000a81548160ff02191690831515021790555060008082815260200190815260200160002060020160008154809291906001019190505550807ffff3c900d938d21d0990d786e819f29b8d05c1ef587b462b939609625b684b1660405160405180910390a250565b60025481565b6000602052806000526040600020600091509050806000015490806001018054600181600116156101000203166002900480601f01602080910402602001604051908101604052809291908181526020018280546001816001161561010002031660029004801561049e5780601f106104735761010080835404028352916020019161049e565b820191906000526020600020905b81548152906001019060200180831161048157829003601f168201915b5050505050908060020154905083565b60035481565b60016020528060005260406000206000915090508060000154908060010160009054906101000a900460ff16908060010160019054906101000a900460ff16908060020154908060030154905085565b60001515600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160009054906101000a900460ff1615151480156105a9575080600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000015414155b15156105b457600080fd5b60036000815480929190600101919050555060a060405190810160405280828152602001600115158152602001600015158152602001600081526020016000815250600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000820151816000015560208201518160010160006101000a81548160ff02191690831515021790555060408201518160010160016101000a81548160ff0219169083151502179055506060820151816002015560808201518160030155905050807fdf46bb731dd3f934fde468a9d86e0ccf9197f737d59f9df5e4d75f380a44e2d960405160405180910390a2505600a165627a7a723058202c4a17e625db51d72d0780b3bb0c53dceb2af686d07f50d1f42ca602f9c2347c0029",
+  "sourceMap": "28:2616:1:-;;;1080:282;8:9:-1;5:2;;;30:1;27;20:12;5:2;1080:282:1;1108:27;;;;;;;;;;;;;;;;;;;:12;;;:27;;;:::i;:::-;1139;;;;;;;;;;;;;;;;;;;:12;;;:27;;;:::i;:::-;28:2616;;1457:137;1504:15;;:17;;;;;;;;;;;;;1554:36;;;;;;;;;1564:15;;1554:36;;;;1581:5;1554:36;;;;1588:1;1554:36;;;1524:10;:27;1535:15;;1524:27;;;;;;;;;;;:66;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;1457:137;:::o;28:2616::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;:::o;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;:::o;:::-;;;;;;;",
+  "deployedSourceMap": "28:2616:1:-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;2037:604;;8:9:-1;5:2;;;30:1;27;20:12;5:2;2037:604:1;;;;;;;;;;;;;;;;;;;;;;;;;;957:27;;8:9:-1;5:2;;;30:1;27;20:12;5:2;957:27:1;;;;;;;;;;;;;;;;;;;;;;;578:44;;8:9:-1;5:2;;;30:1;27;20:12;5:2;578:44:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;23:1:-1;8:100;33:3;30:1;27:10;8:100;;;99:1;94:3;90:11;84:18;80:1;75:3;71:11;64:39;52:2;49:1;45:10;40:15;;8:100;;;12:14;578:44:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1021:23;;8:9:-1;5:2;;;30:1;27;20:12;5:2;1021:23:1;;;;;;;;;;;;;;;;;;;;;;;690:39;;8:9:-1;5:2;;;30:1;27;20:12;5:2;690:39:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1639:394;;8:9:-1;5:2;;;30:1;27;20:12;5:2;1639:394:1;;;;;;;;;;;;;;;;;;;;;;;;;;2037:604;2167:4;2133:38;;:6;:18;2140:10;2133:18;;;;;;;;;;;;;;;:30;;;;;;;;;;;;:38;;;2125:47;;;;;;;;2245:6;:18;2252:10;2245:18;;;;;;;;;;;;;;;:27;;;;;;;;;;;;2244:28;2236:37;;;;;;;;2347:1;2332:12;:16;:51;;;;;2368:15;;2352:12;:31;;2332:51;2324:60;;;;;;;;2467:4;2437:6;:18;2444:10;2437:18;;;;;;;;;;;;;;;:27;;;:34;;;;;;;;;;;;;;;;;;2524:10;:24;2535:12;2524:24;;;;;;;;;;;:34;;;:36;;;;;;;;;;;;;2620:12;2609:24;;;;;;;;;;2037:604;:::o;957:27::-;;;;:::o;578:44::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::o;1021:23::-;;;;:::o;690:39::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::o;1639:394::-;1727:5;1693:39;;:6;:18;1700:10;1693:18;;;;;;;;;;;;;;;:30;;;;;;;;;;;;:39;;;:80;;;;;1762:11;1736:6;:18;1743:10;1736:18;;;;;;;;;;;;;;;:22;;;:37;;1693:80;1685:89;;;;;;;;1864:11;;:13;;;;;;;;;;;;;1901:33;;;;;;;;;1907:11;1901:33;;;;1919:4;1901:33;;;;;;1924:5;1901:33;;;;;;1930:1;1901:33;;;;1932:1;1901:33;;;1880:6;:18;1887:10;1880:18;;;;;;;;;;;;;;;:54;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;2017:11;2008:21;;;;;;;;;;1639:394;:::o",
+  "source": "pragma solidity ^0.4.23;\r\n\r\ncontract Election {\r\n// Model a Candidate\r\n struct Candidate {\r\n\tuint id;\r\n\tstring name;\r\n\tuint voteCount;\r\n}\r\n//Modle a voter\r\nstruct Voter {\r\n  uint NID;     // govt issued national identification number of candidate\r\n  bool eligibility;      // stores the valid list of voters during registration\r\n  bool hasVoted;    // updates when vote is successfully casted on blockchain\r\n  uint blindedVote;    // stores each voter's hashed vote\r\n  uint signedBlindedVote;  // blind signature of casted vote\r\n}\r\n// Candidate ID mapped with candidate struct\r\nmapping(uint => Candidate) public candidates;\r\n\r\n// voter address mapped with voter's details and vote details\r\nmapping(address => Voter) public voters;\r\n\r\n// event for logging successful votes\r\nevent votedEvent(\r\n  uint indexed _candidateId\r\n  );\r\n\r\n// event for logging successful voter registration\r\nevent newVoter(\r\n  uint indexed _nationalID\r\n);\r\n// Store Candidates Count\r\nuint public candidatesCount;   // counter cache for candidates\r\nuint public votersCount;    // counter cache for voters\r\n\r\nconstructor() public {\r\n\r\n  addCandidate(\"Candidate 1\");\r\n\taddCandidate(\"Candidate 2\");\r\n//  addVoter(100);   addvoter() function is not used in constructor statement because it invokes require(), but the contract hasn't beem created before constructor call\r\n//  addVoter(200);\r\n  }\r\n\r\n// candidates are pre populated for the election (privately intitialized by the contract)\r\nfunction addCandidate(string _name) private {\r\ncandidatesCount++;\r\ncandidates[candidatesCount] = Candidate(candidatesCount, _name, 0);\r\n}\r\n\r\n// anyone can register for the election\r\nfunction addVoter(uint _nationalID) public {\r\nrequire(voters[msg.sender].eligibility == false && voters[msg.sender].NID != _nationalID);  //checks if voter has registered before with same NID / Disallows Double Registration\r\nvotersCount++;\r\nvoters[msg.sender] = Voter(_nationalID,true,false,0,0);   // (NID, eligibility, hasVoted, BlindedVote, signedBlindedVote)\r\nemit newVoter(_nationalID);\r\n}\r\n\r\nfunction vote(uint _candidateId) public {\r\n\r\n        // registered voter check\r\n        require(voters[msg.sender].eligibility == true);\r\n\r\n        // require that they haven't voted before\r\n        require(!voters[msg.sender].hasVoted);\r\n\r\n        // require a valid candidate\r\n        require(_candidateId > 0 && _candidateId <= candidatesCount);\r\n\r\n        // record that voter has voted\r\n        voters[msg.sender].hasVoted = true;\r\n\r\n        // update candidate vote Count\r\n        candidates[_candidateId].voteCount++;\r\n\r\n        //trigger voted event\r\n        emit votedEvent(_candidateId);\r\n    }\r\n}\r\n",
   "sourcePath": "L:/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/election.sol",
   "ast": {
     "absolutePath": "/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/election.sol",
@@ -427,7 +427,7 @@
             "name": "candidates",
             "nodeType": "VariableDeclaration",
             "scope": 225,
-            "src": "558:44:1",
+            "src": "578:44:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -440,14 +440,14 @@
                 "id": 77,
                 "name": "uint",
                 "nodeType": "ElementaryTypeName",
-                "src": "566:4:1",
+                "src": "586:4:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_uint256",
                   "typeString": "uint256"
                 }
               },
               "nodeType": "Mapping",
-              "src": "558:26:1",
+              "src": "578:26:1",
               "typeDescriptions": {
                 "typeIdentifier": "t_mapping$_t_uint256_$_t_struct$_Candidate_$65_storage_$",
                 "typeString": "mapping(uint256 => struct Election.Candidate)"
@@ -458,7 +458,7 @@
                 "name": "Candidate",
                 "nodeType": "UserDefinedTypeName",
                 "referencedDeclaration": 65,
-                "src": "574:9:1",
+                "src": "594:9:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_struct$_Candidate_$65_storage_ptr",
                   "typeString": "struct Election.Candidate"
@@ -474,7 +474,7 @@
             "name": "voters",
             "nodeType": "VariableDeclaration",
             "scope": 225,
-            "src": "642:39:1",
+            "src": "690:39:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -487,14 +487,14 @@
                 "id": 81,
                 "name": "address",
                 "nodeType": "ElementaryTypeName",
-                "src": "650:7:1",
+                "src": "698:7:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_address",
                   "typeString": "address"
                 }
               },
               "nodeType": "Mapping",
-              "src": "642:25:1",
+              "src": "690:25:1",
               "typeDescriptions": {
                 "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
                 "typeString": "mapping(address => struct Election.Voter)"
@@ -505,7 +505,7 @@
                 "name": "Voter",
                 "nodeType": "UserDefinedTypeName",
                 "referencedDeclaration": 76,
-                "src": "661:5:1",
+                "src": "709:5:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_struct$_Voter_$76_storage_ptr",
                   "typeString": "struct Election.Voter"
@@ -532,7 +532,7 @@
                   "name": "_candidateId",
                   "nodeType": "VariableDeclaration",
                   "scope": 88,
-                  "src": "746:25:1",
+                  "src": "794:25:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -543,7 +543,7 @@
                     "id": 85,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
-                    "src": "746:4:1",
+                    "src": "794:4:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -553,9 +553,9 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "741:35:1"
+              "src": "789:35:1"
             },
-            "src": "725:52:1"
+            "src": "773:52:1"
           },
           {
             "anonymous": false,
@@ -574,7 +574,7 @@
                   "name": "_nationalID",
                   "nodeType": "VariableDeclaration",
                   "scope": 92,
-                  "src": "839:24:1",
+                  "src": "900:24:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -585,7 +585,7 @@
                     "id": 89,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
-                    "src": "839:4:1",
+                    "src": "900:4:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -595,9 +595,9 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "834:32:1"
+              "src": "895:32:1"
             },
-            "src": "820:47:1"
+            "src": "881:47:1"
           },
           {
             "constant": false,
@@ -605,7 +605,7 @@
             "name": "candidatesCount",
             "nodeType": "VariableDeclaration",
             "scope": 225,
-            "src": "896:27:1",
+            "src": "957:27:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -616,7 +616,7 @@
               "id": 93,
               "name": "uint",
               "nodeType": "ElementaryTypeName",
-              "src": "896:4:1",
+              "src": "957:4:1",
               "typeDescriptions": {
                 "typeIdentifier": "t_uint256",
                 "typeString": "uint256"
@@ -631,7 +631,7 @@
             "name": "votersCount",
             "nodeType": "VariableDeclaration",
             "scope": 225,
-            "src": "960:23:1",
+            "src": "1021:23:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -642,7 +642,7 @@
               "id": 95,
               "name": "uint",
               "nodeType": "ElementaryTypeName",
-              "src": "960:4:1",
+              "src": "1021:4:1",
               "typeDescriptions": {
                 "typeIdentifier": "t_uint256",
                 "typeString": "uint256"
@@ -655,7 +655,7 @@
             "body": {
               "id": 107,
               "nodeType": "Block",
-              "src": "1178:528:1",
+              "src": "1101:261:1",
               "statements": [
                 {
                   "expression": {
@@ -671,7 +671,7 @@
                         "kind": "string",
                         "lValueRequested": false,
                         "nodeType": "Literal",
-                        "src": "1198:13:1",
+                        "src": "1121:13:1",
                         "subdenomination": null,
                         "typeDescriptions": {
                           "typeIdentifier": "t_stringliteral_41f9dcbd43e9b33194759b5a51b1df9864cdc2b2138ff106f03091eb79861f0c",
@@ -692,7 +692,7 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 127,
-                      "src": "1185:12:1",
+                      "src": "1108:12:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_nonpayable$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (string memory)"
@@ -706,7 +706,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1185:27:1",
+                    "src": "1108:27:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
@@ -714,7 +714,7 @@
                   },
                   "id": 102,
                   "nodeType": "ExpressionStatement",
-                  "src": "1185:27:1"
+                  "src": "1108:27:1"
                 },
                 {
                   "expression": {
@@ -730,7 +730,7 @@
                         "kind": "string",
                         "lValueRequested": false,
                         "nodeType": "Literal",
-                        "src": "1229:13:1",
+                        "src": "1152:13:1",
                         "subdenomination": null,
                         "typeDescriptions": {
                           "typeIdentifier": "t_stringliteral_f1f17440f69835dafba5c9fd0e4caa6c780807a80f8d1745ec7af1408d6cca4a",
@@ -751,7 +751,7 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 127,
-                      "src": "1216:12:1",
+                      "src": "1139:12:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_nonpayable$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (string memory)"
@@ -765,7 +765,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1216:27:1",
+                    "src": "1139:27:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
@@ -773,7 +773,7 @@
                   },
                   "id": 106,
                   "nodeType": "ExpressionStatement",
-                  "src": "1216:27:1"
+                  "src": "1139:27:1"
                 }
               ]
             },
@@ -789,17 +789,17 @@
               "id": 97,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "1168:2:1"
+              "src": "1091:2:1"
             },
             "payable": false,
             "returnParameters": {
               "id": 98,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "1178:0:1"
+              "src": "1101:0:1"
             },
             "scope": 225,
-            "src": "1157:549:1",
+            "src": "1080:282:1",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
@@ -808,7 +808,7 @@
             "body": {
               "id": 126,
               "nodeType": "Block",
-              "src": "1804:93:1",
+              "src": "1501:93:1",
               "statements": [
                 {
                   "expression": {
@@ -821,7 +821,7 @@
                     "nodeType": "UnaryOperation",
                     "operator": "++",
                     "prefix": false,
-                    "src": "1807:17:1",
+                    "src": "1504:17:1",
                     "subExpression": {
                       "argumentTypes": null,
                       "id": 113,
@@ -829,7 +829,7 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 94,
-                      "src": "1807:15:1",
+                      "src": "1504:15:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
@@ -842,7 +842,7 @@
                   },
                   "id": 115,
                   "nodeType": "ExpressionStatement",
-                  "src": "1807:17:1"
+                  "src": "1504:17:1"
                 },
                 {
                   "expression": {
@@ -861,7 +861,7 @@
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 80,
-                        "src": "1827:10:1",
+                        "src": "1524:10:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_uint256_$_t_struct$_Candidate_$65_storage_$",
                           "typeString": "mapping(uint256 => struct Election.Candidate storage ref)"
@@ -875,7 +875,7 @@
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 94,
-                        "src": "1838:15:1",
+                        "src": "1535:15:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
@@ -886,7 +886,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "1827:27:1",
+                      "src": "1524:27:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_struct$_Candidate_$65_storage",
                         "typeString": "struct Election.Candidate storage ref"
@@ -904,7 +904,7 @@
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 94,
-                          "src": "1867:15:1",
+                          "src": "1564:15:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
@@ -917,7 +917,7 @@
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 110,
-                          "src": "1884:5:1",
+                          "src": "1581:5:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_string_memory_ptr",
                             "typeString": "string memory"
@@ -933,7 +933,7 @@
                           "kind": "number",
                           "lValueRequested": false,
                           "nodeType": "Literal",
-                          "src": "1891:1:1",
+                          "src": "1588:1:1",
                           "subdenomination": null,
                           "typeDescriptions": {
                             "typeIdentifier": "t_rational_0_by_1",
@@ -962,7 +962,7 @@
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 65,
-                        "src": "1857:9:1",
+                        "src": "1554:9:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_type$_t_struct$_Candidate_$65_storage_ptr_$",
                           "typeString": "type(struct Election.Candidate storage pointer)"
@@ -976,13 +976,13 @@
                       "lValueRequested": false,
                       "names": [],
                       "nodeType": "FunctionCall",
-                      "src": "1857:36:1",
+                      "src": "1554:36:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_struct$_Candidate_$65_memory",
                         "typeString": "struct Election.Candidate memory"
                       }
                     },
-                    "src": "1827:66:1",
+                    "src": "1524:66:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_struct$_Candidate_$65_storage",
                       "typeString": "struct Election.Candidate storage ref"
@@ -990,7 +990,7 @@
                   },
                   "id": 125,
                   "nodeType": "ExpressionStatement",
-                  "src": "1827:66:1"
+                  "src": "1524:66:1"
                 }
               ]
             },
@@ -1012,7 +1012,7 @@
                   "name": "_name",
                   "nodeType": "VariableDeclaration",
                   "scope": 127,
-                  "src": "1782:12:1",
+                  "src": "1479:12:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1023,7 +1023,7 @@
                     "id": 109,
                     "name": "string",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1782:6:1",
+                    "src": "1479:6:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_string_storage_ptr",
                       "typeString": "string"
@@ -1033,17 +1033,17 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "1781:14:1"
+              "src": "1478:14:1"
             },
             "payable": false,
             "returnParameters": {
               "id": 112,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "1804:0:1"
+              "src": "1501:0:1"
             },
             "scope": 225,
-            "src": "1760:137:1",
+            "src": "1457:137:1",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "private"
@@ -1052,7 +1052,7 @@
             "body": {
               "id": 170,
               "nodeType": "Block",
-              "src": "1985:351:1",
+              "src": "1682:351:1",
               "statements": [
                 {
                   "expression": {
@@ -1091,7 +1091,7 @@
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
                                 "referencedDeclaration": 84,
-                                "src": "1996:6:1",
+                                "src": "1693:6:1",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
                                   "typeString": "mapping(address => struct Election.Voter storage ref)"
@@ -1107,7 +1107,7 @@
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
                                   "referencedDeclaration": 240,
-                                  "src": "2003:3:1",
+                                  "src": "1700:3:1",
                                   "typeDescriptions": {
                                     "typeIdentifier": "t_magic_message",
                                     "typeString": "msg"
@@ -1121,7 +1121,7 @@
                                 "memberName": "sender",
                                 "nodeType": "MemberAccess",
                                 "referencedDeclaration": null,
-                                "src": "2003:10:1",
+                                "src": "1700:10:1",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_address",
                                   "typeString": "address"
@@ -1132,7 +1132,7 @@
                               "isPure": false,
                               "lValueRequested": false,
                               "nodeType": "IndexAccess",
-                              "src": "1996:18:1",
+                              "src": "1693:18:1",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_struct$_Voter_$76_storage",
                                 "typeString": "struct Election.Voter storage ref"
@@ -1146,7 +1146,7 @@
                             "memberName": "eligibility",
                             "nodeType": "MemberAccess",
                             "referencedDeclaration": 69,
-                            "src": "1996:30:1",
+                            "src": "1693:30:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_bool",
                               "typeString": "bool"
@@ -1164,7 +1164,7 @@
                             "kind": "bool",
                             "lValueRequested": false,
                             "nodeType": "Literal",
-                            "src": "2030:5:1",
+                            "src": "1727:5:1",
                             "subdenomination": null,
                             "typeDescriptions": {
                               "typeIdentifier": "t_bool",
@@ -1172,7 +1172,7 @@
                             },
                             "value": "false"
                           },
-                          "src": "1996:39:1",
+                          "src": "1693:39:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
@@ -1202,7 +1202,7 @@
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
                                 "referencedDeclaration": 84,
-                                "src": "2039:6:1",
+                                "src": "1736:6:1",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
                                   "typeString": "mapping(address => struct Election.Voter storage ref)"
@@ -1218,7 +1218,7 @@
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
                                   "referencedDeclaration": 240,
-                                  "src": "2046:3:1",
+                                  "src": "1743:3:1",
                                   "typeDescriptions": {
                                     "typeIdentifier": "t_magic_message",
                                     "typeString": "msg"
@@ -1232,7 +1232,7 @@
                                 "memberName": "sender",
                                 "nodeType": "MemberAccess",
                                 "referencedDeclaration": null,
-                                "src": "2046:10:1",
+                                "src": "1743:10:1",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_address",
                                   "typeString": "address"
@@ -1243,7 +1243,7 @@
                               "isPure": false,
                               "lValueRequested": false,
                               "nodeType": "IndexAccess",
-                              "src": "2039:18:1",
+                              "src": "1736:18:1",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_struct$_Voter_$76_storage",
                                 "typeString": "struct Election.Voter storage ref"
@@ -1257,7 +1257,7 @@
                             "memberName": "NID",
                             "nodeType": "MemberAccess",
                             "referencedDeclaration": 67,
-                            "src": "2039:22:1",
+                            "src": "1736:22:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
@@ -1272,19 +1272,19 @@
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
                             "referencedDeclaration": 129,
-                            "src": "2065:11:1",
+                            "src": "1762:11:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
                             }
                           },
-                          "src": "2039:37:1",
+                          "src": "1736:37:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
                           }
                         },
-                        "src": "1996:80:1",
+                        "src": "1693:80:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
@@ -1306,7 +1306,7 @@
                         244
                       ],
                       "referencedDeclaration": 243,
-                      "src": "1988:7:1",
+                      "src": "1685:7:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
                         "typeString": "function (bool) pure"
@@ -1320,7 +1320,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1988:89:1",
+                    "src": "1685:89:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
@@ -1328,7 +1328,7 @@
                   },
                   "id": 149,
                   "nodeType": "ExpressionStatement",
-                  "src": "1988:89:1"
+                  "src": "1685:89:1"
                 },
                 {
                   "expression": {
@@ -1341,7 +1341,7 @@
                     "nodeType": "UnaryOperation",
                     "operator": "++",
                     "prefix": false,
-                    "src": "2167:13:1",
+                    "src": "1864:13:1",
                     "subExpression": {
                       "argumentTypes": null,
                       "id": 150,
@@ -1349,7 +1349,7 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 96,
-                      "src": "2167:11:1",
+                      "src": "1864:11:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
@@ -1362,7 +1362,7 @@
                   },
                   "id": 152,
                   "nodeType": "ExpressionStatement",
-                  "src": "2167:13:1"
+                  "src": "1864:13:1"
                 },
                 {
                   "expression": {
@@ -1381,7 +1381,7 @@
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 84,
-                        "src": "2183:6:1",
+                        "src": "1880:6:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
                           "typeString": "mapping(address => struct Election.Voter storage ref)"
@@ -1397,7 +1397,7 @@
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 240,
-                          "src": "2190:3:1",
+                          "src": "1887:3:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_magic_message",
                             "typeString": "msg"
@@ -1411,7 +1411,7 @@
                         "memberName": "sender",
                         "nodeType": "MemberAccess",
                         "referencedDeclaration": null,
-                        "src": "2190:10:1",
+                        "src": "1887:10:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
                           "typeString": "address"
@@ -1422,7 +1422,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "2183:18:1",
+                      "src": "1880:18:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_struct$_Voter_$76_storage",
                         "typeString": "struct Election.Voter storage ref"
@@ -1440,7 +1440,7 @@
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 129,
-                          "src": "2210:11:1",
+                          "src": "1907:11:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
@@ -1456,7 +1456,7 @@
                           "kind": "bool",
                           "lValueRequested": false,
                           "nodeType": "Literal",
-                          "src": "2222:4:1",
+                          "src": "1919:4:1",
                           "subdenomination": null,
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
@@ -1474,7 +1474,7 @@
                           "kind": "bool",
                           "lValueRequested": false,
                           "nodeType": "Literal",
-                          "src": "2227:5:1",
+                          "src": "1924:5:1",
                           "subdenomination": null,
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
@@ -1492,7 +1492,7 @@
                           "kind": "number",
                           "lValueRequested": false,
                           "nodeType": "Literal",
-                          "src": "2233:1:1",
+                          "src": "1930:1:1",
                           "subdenomination": null,
                           "typeDescriptions": {
                             "typeIdentifier": "t_rational_0_by_1",
@@ -1510,7 +1510,7 @@
                           "kind": "number",
                           "lValueRequested": false,
                           "nodeType": "Literal",
-                          "src": "2235:1:1",
+                          "src": "1932:1:1",
                           "subdenomination": null,
                           "typeDescriptions": {
                             "typeIdentifier": "t_rational_0_by_1",
@@ -1547,7 +1547,7 @@
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 76,
-                        "src": "2204:5:1",
+                        "src": "1901:5:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_type$_t_struct$_Voter_$76_storage_ptr_$",
                           "typeString": "type(struct Election.Voter storage pointer)"
@@ -1561,13 +1561,13 @@
                       "lValueRequested": false,
                       "names": [],
                       "nodeType": "FunctionCall",
-                      "src": "2204:33:1",
+                      "src": "1901:33:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_struct$_Voter_$76_memory",
                         "typeString": "struct Election.Voter memory"
                       }
                     },
-                    "src": "2183:54:1",
+                    "src": "1880:54:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_struct$_Voter_$76_storage",
                       "typeString": "struct Election.Voter storage ref"
@@ -1575,7 +1575,7 @@
                   },
                   "id": 165,
                   "nodeType": "ExpressionStatement",
-                  "src": "2183:54:1"
+                  "src": "1880:54:1"
                 },
                 {
                   "eventCall": {
@@ -1588,7 +1588,7 @@
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 129,
-                        "src": "2320:11:1",
+                        "src": "2017:11:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
@@ -1607,7 +1607,7 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 92,
-                      "src": "2311:8:1",
+                      "src": "2008:8:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_event_nonpayable$_t_uint256_$returns$__$",
                         "typeString": "function (uint256)"
@@ -1621,7 +1621,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "2311:21:1",
+                    "src": "2008:21:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
@@ -1629,7 +1629,7 @@
                   },
                   "id": 169,
                   "nodeType": "EmitStatement",
-                  "src": "2306:26:1"
+                  "src": "2003:26:1"
                 }
               ]
             },
@@ -1651,7 +1651,7 @@
                   "name": "_nationalID",
                   "nodeType": "VariableDeclaration",
                   "scope": 171,
-                  "src": "1960:16:1",
+                  "src": "1657:16:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1662,7 +1662,7 @@
                     "id": 128,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1960:4:1",
+                    "src": "1657:4:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -1672,17 +1672,17 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "1959:18:1"
+              "src": "1656:18:1"
             },
             "payable": false,
             "returnParameters": {
               "id": 131,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "1985:0:1"
+              "src": "1682:0:1"
             },
             "scope": 225,
-            "src": "1942:394:1",
+            "src": "1639:394:1",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
@@ -1691,7 +1691,7 @@
             "body": {
               "id": 223,
               "nodeType": "Block",
-              "src": "2380:564:1",
+              "src": "2077:564:1",
               "statements": [
                 {
                   "expression": {
@@ -1719,7 +1719,7 @@
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
                               "referencedDeclaration": 84,
-                              "src": "2436:6:1",
+                              "src": "2133:6:1",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
                                 "typeString": "mapping(address => struct Election.Voter storage ref)"
@@ -1735,7 +1735,7 @@
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
                                 "referencedDeclaration": 240,
-                                "src": "2443:3:1",
+                                "src": "2140:3:1",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_magic_message",
                                   "typeString": "msg"
@@ -1749,7 +1749,7 @@
                               "memberName": "sender",
                               "nodeType": "MemberAccess",
                               "referencedDeclaration": null,
-                              "src": "2443:10:1",
+                              "src": "2140:10:1",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_address",
                                 "typeString": "address"
@@ -1760,7 +1760,7 @@
                             "isPure": false,
                             "lValueRequested": false,
                             "nodeType": "IndexAccess",
-                            "src": "2436:18:1",
+                            "src": "2133:18:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_struct$_Voter_$76_storage",
                               "typeString": "struct Election.Voter storage ref"
@@ -1774,7 +1774,7 @@
                           "memberName": "eligibility",
                           "nodeType": "MemberAccess",
                           "referencedDeclaration": 69,
-                          "src": "2436:30:1",
+                          "src": "2133:30:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
@@ -1792,7 +1792,7 @@
                           "kind": "bool",
                           "lValueRequested": false,
                           "nodeType": "Literal",
-                          "src": "2470:4:1",
+                          "src": "2167:4:1",
                           "subdenomination": null,
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
@@ -1800,7 +1800,7 @@
                           },
                           "value": "true"
                         },
-                        "src": "2436:38:1",
+                        "src": "2133:38:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
@@ -1822,7 +1822,7 @@
                         244
                       ],
                       "referencedDeclaration": 243,
-                      "src": "2428:7:1",
+                      "src": "2125:7:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
                         "typeString": "function (bool) pure"
@@ -1836,7 +1836,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "2428:47:1",
+                    "src": "2125:47:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
@@ -1844,7 +1844,7 @@
                   },
                   "id": 185,
                   "nodeType": "ExpressionStatement",
-                  "src": "2428:47:1"
+                  "src": "2125:47:1"
                 },
                 {
                   "expression": {
@@ -1860,7 +1860,7 @@
                         "nodeType": "UnaryOperation",
                         "operator": "!",
                         "prefix": true,
-                        "src": "2547:28:1",
+                        "src": "2244:28:1",
                         "subExpression": {
                           "argumentTypes": null,
                           "expression": {
@@ -1872,7 +1872,7 @@
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
                               "referencedDeclaration": 84,
-                              "src": "2548:6:1",
+                              "src": "2245:6:1",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
                                 "typeString": "mapping(address => struct Election.Voter storage ref)"
@@ -1888,7 +1888,7 @@
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
                                 "referencedDeclaration": 240,
-                                "src": "2555:3:1",
+                                "src": "2252:3:1",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_magic_message",
                                   "typeString": "msg"
@@ -1902,7 +1902,7 @@
                               "memberName": "sender",
                               "nodeType": "MemberAccess",
                               "referencedDeclaration": null,
-                              "src": "2555:10:1",
+                              "src": "2252:10:1",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_address",
                                 "typeString": "address"
@@ -1913,7 +1913,7 @@
                             "isPure": false,
                             "lValueRequested": false,
                             "nodeType": "IndexAccess",
-                            "src": "2548:18:1",
+                            "src": "2245:18:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_struct$_Voter_$76_storage",
                               "typeString": "struct Election.Voter storage ref"
@@ -1927,7 +1927,7 @@
                           "memberName": "hasVoted",
                           "nodeType": "MemberAccess",
                           "referencedDeclaration": 71,
-                          "src": "2548:27:1",
+                          "src": "2245:27:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
@@ -1954,7 +1954,7 @@
                         244
                       ],
                       "referencedDeclaration": 243,
-                      "src": "2539:7:1",
+                      "src": "2236:7:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
                         "typeString": "function (bool) pure"
@@ -1968,7 +1968,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "2539:37:1",
+                    "src": "2236:37:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
@@ -1976,7 +1976,7 @@
                   },
                   "id": 194,
                   "nodeType": "ExpressionStatement",
-                  "src": "2539:37:1"
+                  "src": "2236:37:1"
                 },
                 {
                   "expression": {
@@ -2011,7 +2011,7 @@
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
                             "referencedDeclaration": 173,
-                            "src": "2635:12:1",
+                            "src": "2332:12:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
@@ -2029,7 +2029,7 @@
                             "kind": "number",
                             "lValueRequested": false,
                             "nodeType": "Literal",
-                            "src": "2650:1:1",
+                            "src": "2347:1:1",
                             "subdenomination": null,
                             "typeDescriptions": {
                               "typeIdentifier": "t_rational_0_by_1",
@@ -2037,7 +2037,7 @@
                             },
                             "value": "0"
                           },
-                          "src": "2635:16:1",
+                          "src": "2332:16:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
@@ -2063,7 +2063,7 @@
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
                             "referencedDeclaration": 173,
-                            "src": "2655:12:1",
+                            "src": "2352:12:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
@@ -2078,19 +2078,19 @@
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
                             "referencedDeclaration": 94,
-                            "src": "2671:15:1",
+                            "src": "2368:15:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
                             }
                           },
-                          "src": "2655:31:1",
+                          "src": "2352:31:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
                           }
                         },
-                        "src": "2635:51:1",
+                        "src": "2332:51:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
@@ -2112,7 +2112,7 @@
                         244
                       ],
                       "referencedDeclaration": 243,
-                      "src": "2627:7:1",
+                      "src": "2324:7:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
                         "typeString": "function (bool) pure"
@@ -2126,7 +2126,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "2627:60:1",
+                    "src": "2324:60:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
@@ -2134,7 +2134,7 @@
                   },
                   "id": 204,
                   "nodeType": "ExpressionStatement",
-                  "src": "2627:60:1"
+                  "src": "2324:60:1"
                 },
                 {
                   "expression": {
@@ -2155,7 +2155,7 @@
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 84,
-                          "src": "2740:6:1",
+                          "src": "2437:6:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
                             "typeString": "mapping(address => struct Election.Voter storage ref)"
@@ -2171,7 +2171,7 @@
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
                             "referencedDeclaration": 240,
-                            "src": "2747:3:1",
+                            "src": "2444:3:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_magic_message",
                               "typeString": "msg"
@@ -2185,7 +2185,7 @@
                           "memberName": "sender",
                           "nodeType": "MemberAccess",
                           "referencedDeclaration": null,
-                          "src": "2747:10:1",
+                          "src": "2444:10:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -2196,7 +2196,7 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "2740:18:1",
+                        "src": "2437:18:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_struct$_Voter_$76_storage",
                           "typeString": "struct Election.Voter storage ref"
@@ -2210,7 +2210,7 @@
                       "memberName": "hasVoted",
                       "nodeType": "MemberAccess",
                       "referencedDeclaration": 71,
-                      "src": "2740:27:1",
+                      "src": "2437:27:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
                         "typeString": "bool"
@@ -2228,7 +2228,7 @@
                       "kind": "bool",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "2770:4:1",
+                      "src": "2467:4:1",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
@@ -2236,7 +2236,7 @@
                       },
                       "value": "true"
                     },
-                    "src": "2740:34:1",
+                    "src": "2437:34:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
@@ -2244,7 +2244,7 @@
                   },
                   "id": 212,
                   "nodeType": "ExpressionStatement",
-                  "src": "2740:34:1"
+                  "src": "2437:34:1"
                 },
                 {
                   "expression": {
@@ -2257,7 +2257,7 @@
                     "nodeType": "UnaryOperation",
                     "operator": "++",
                     "prefix": false,
-                    "src": "2827:36:1",
+                    "src": "2524:36:1",
                     "subExpression": {
                       "argumentTypes": null,
                       "expression": {
@@ -2269,7 +2269,7 @@
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 80,
-                          "src": "2827:10:1",
+                          "src": "2524:10:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_uint256_$_t_struct$_Candidate_$65_storage_$",
                             "typeString": "mapping(uint256 => struct Election.Candidate storage ref)"
@@ -2283,7 +2283,7 @@
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 173,
-                          "src": "2838:12:1",
+                          "src": "2535:12:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
@@ -2294,7 +2294,7 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "2827:24:1",
+                        "src": "2524:24:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_struct$_Candidate_$65_storage",
                           "typeString": "struct Election.Candidate storage ref"
@@ -2308,7 +2308,7 @@
                       "memberName": "voteCount",
                       "nodeType": "MemberAccess",
                       "referencedDeclaration": 64,
-                      "src": "2827:34:1",
+                      "src": "2524:34:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
@@ -2321,7 +2321,7 @@
                   },
                   "id": 218,
                   "nodeType": "ExpressionStatement",
-                  "src": "2827:36:1"
+                  "src": "2524:36:1"
                 },
                 {
                   "eventCall": {
@@ -2334,7 +2334,7 @@
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 173,
-                        "src": "2923:12:1",
+                        "src": "2620:12:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
@@ -2353,7 +2353,7 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 88,
-                      "src": "2912:10:1",
+                      "src": "2609:10:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_event_nonpayable$_t_uint256_$returns$__$",
                         "typeString": "function (uint256)"
@@ -2367,7 +2367,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "2912:24:1",
+                    "src": "2609:24:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
@@ -2375,7 +2375,7 @@
                   },
                   "id": 222,
                   "nodeType": "EmitStatement",
-                  "src": "2907:29:1"
+                  "src": "2604:29:1"
                 }
               ]
             },
@@ -2397,7 +2397,7 @@
                   "name": "_candidateId",
                   "nodeType": "VariableDeclaration",
                   "scope": 224,
-                  "src": "2354:17:1",
+                  "src": "2051:17:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2408,7 +2408,7 @@
                     "id": 172,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
-                    "src": "2354:4:1",
+                    "src": "2051:4:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -2418,27 +2418,27 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "2353:19:1"
+              "src": "2050:19:1"
             },
             "payable": false,
             "returnParameters": {
               "id": 175,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "2380:0:1"
+              "src": "2077:0:1"
             },
             "scope": 225,
-            "src": "2340:604:1",
+            "src": "2037:604:1",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
           }
         ],
         "scope": 226,
-        "src": "28:2919:1"
+        "src": "28:2616:1"
       }
     ],
-    "src": "0:2949:1"
+    "src": "0:2646:1"
   },
   "legacyAST": {
     "absolutePath": "/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/election.sol",
@@ -2710,7 +2710,7 @@
             "name": "candidates",
             "nodeType": "VariableDeclaration",
             "scope": 225,
-            "src": "558:44:1",
+            "src": "578:44:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -2723,14 +2723,14 @@
                 "id": 77,
                 "name": "uint",
                 "nodeType": "ElementaryTypeName",
-                "src": "566:4:1",
+                "src": "586:4:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_uint256",
                   "typeString": "uint256"
                 }
               },
               "nodeType": "Mapping",
-              "src": "558:26:1",
+              "src": "578:26:1",
               "typeDescriptions": {
                 "typeIdentifier": "t_mapping$_t_uint256_$_t_struct$_Candidate_$65_storage_$",
                 "typeString": "mapping(uint256 => struct Election.Candidate)"
@@ -2741,7 +2741,7 @@
                 "name": "Candidate",
                 "nodeType": "UserDefinedTypeName",
                 "referencedDeclaration": 65,
-                "src": "574:9:1",
+                "src": "594:9:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_struct$_Candidate_$65_storage_ptr",
                   "typeString": "struct Election.Candidate"
@@ -2757,7 +2757,7 @@
             "name": "voters",
             "nodeType": "VariableDeclaration",
             "scope": 225,
-            "src": "642:39:1",
+            "src": "690:39:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -2770,14 +2770,14 @@
                 "id": 81,
                 "name": "address",
                 "nodeType": "ElementaryTypeName",
-                "src": "650:7:1",
+                "src": "698:7:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_address",
                   "typeString": "address"
                 }
               },
               "nodeType": "Mapping",
-              "src": "642:25:1",
+              "src": "690:25:1",
               "typeDescriptions": {
                 "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
                 "typeString": "mapping(address => struct Election.Voter)"
@@ -2788,7 +2788,7 @@
                 "name": "Voter",
                 "nodeType": "UserDefinedTypeName",
                 "referencedDeclaration": 76,
-                "src": "661:5:1",
+                "src": "709:5:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_struct$_Voter_$76_storage_ptr",
                   "typeString": "struct Election.Voter"
@@ -2815,7 +2815,7 @@
                   "name": "_candidateId",
                   "nodeType": "VariableDeclaration",
                   "scope": 88,
-                  "src": "746:25:1",
+                  "src": "794:25:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2826,7 +2826,7 @@
                     "id": 85,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
-                    "src": "746:4:1",
+                    "src": "794:4:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -2836,9 +2836,9 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "741:35:1"
+              "src": "789:35:1"
             },
-            "src": "725:52:1"
+            "src": "773:52:1"
           },
           {
             "anonymous": false,
@@ -2857,7 +2857,7 @@
                   "name": "_nationalID",
                   "nodeType": "VariableDeclaration",
                   "scope": 92,
-                  "src": "839:24:1",
+                  "src": "900:24:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2868,7 +2868,7 @@
                     "id": 89,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
-                    "src": "839:4:1",
+                    "src": "900:4:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -2878,9 +2878,9 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "834:32:1"
+              "src": "895:32:1"
             },
-            "src": "820:47:1"
+            "src": "881:47:1"
           },
           {
             "constant": false,
@@ -2888,7 +2888,7 @@
             "name": "candidatesCount",
             "nodeType": "VariableDeclaration",
             "scope": 225,
-            "src": "896:27:1",
+            "src": "957:27:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -2899,7 +2899,7 @@
               "id": 93,
               "name": "uint",
               "nodeType": "ElementaryTypeName",
-              "src": "896:4:1",
+              "src": "957:4:1",
               "typeDescriptions": {
                 "typeIdentifier": "t_uint256",
                 "typeString": "uint256"
@@ -2914,7 +2914,7 @@
             "name": "votersCount",
             "nodeType": "VariableDeclaration",
             "scope": 225,
-            "src": "960:23:1",
+            "src": "1021:23:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -2925,7 +2925,7 @@
               "id": 95,
               "name": "uint",
               "nodeType": "ElementaryTypeName",
-              "src": "960:4:1",
+              "src": "1021:4:1",
               "typeDescriptions": {
                 "typeIdentifier": "t_uint256",
                 "typeString": "uint256"
@@ -2938,7 +2938,7 @@
             "body": {
               "id": 107,
               "nodeType": "Block",
-              "src": "1178:528:1",
+              "src": "1101:261:1",
               "statements": [
                 {
                   "expression": {
@@ -2954,7 +2954,7 @@
                         "kind": "string",
                         "lValueRequested": false,
                         "nodeType": "Literal",
-                        "src": "1198:13:1",
+                        "src": "1121:13:1",
                         "subdenomination": null,
                         "typeDescriptions": {
                           "typeIdentifier": "t_stringliteral_41f9dcbd43e9b33194759b5a51b1df9864cdc2b2138ff106f03091eb79861f0c",
@@ -2975,7 +2975,7 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 127,
-                      "src": "1185:12:1",
+                      "src": "1108:12:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_nonpayable$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (string memory)"
@@ -2989,7 +2989,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1185:27:1",
+                    "src": "1108:27:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
@@ -2997,7 +2997,7 @@
                   },
                   "id": 102,
                   "nodeType": "ExpressionStatement",
-                  "src": "1185:27:1"
+                  "src": "1108:27:1"
                 },
                 {
                   "expression": {
@@ -3013,7 +3013,7 @@
                         "kind": "string",
                         "lValueRequested": false,
                         "nodeType": "Literal",
-                        "src": "1229:13:1",
+                        "src": "1152:13:1",
                         "subdenomination": null,
                         "typeDescriptions": {
                           "typeIdentifier": "t_stringliteral_f1f17440f69835dafba5c9fd0e4caa6c780807a80f8d1745ec7af1408d6cca4a",
@@ -3034,7 +3034,7 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 127,
-                      "src": "1216:12:1",
+                      "src": "1139:12:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_nonpayable$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (string memory)"
@@ -3048,7 +3048,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1216:27:1",
+                    "src": "1139:27:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
@@ -3056,7 +3056,7 @@
                   },
                   "id": 106,
                   "nodeType": "ExpressionStatement",
-                  "src": "1216:27:1"
+                  "src": "1139:27:1"
                 }
               ]
             },
@@ -3072,17 +3072,17 @@
               "id": 97,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "1168:2:1"
+              "src": "1091:2:1"
             },
             "payable": false,
             "returnParameters": {
               "id": 98,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "1178:0:1"
+              "src": "1101:0:1"
             },
             "scope": 225,
-            "src": "1157:549:1",
+            "src": "1080:282:1",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
@@ -3091,7 +3091,7 @@
             "body": {
               "id": 126,
               "nodeType": "Block",
-              "src": "1804:93:1",
+              "src": "1501:93:1",
               "statements": [
                 {
                   "expression": {
@@ -3104,7 +3104,7 @@
                     "nodeType": "UnaryOperation",
                     "operator": "++",
                     "prefix": false,
-                    "src": "1807:17:1",
+                    "src": "1504:17:1",
                     "subExpression": {
                       "argumentTypes": null,
                       "id": 113,
@@ -3112,7 +3112,7 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 94,
-                      "src": "1807:15:1",
+                      "src": "1504:15:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
@@ -3125,7 +3125,7 @@
                   },
                   "id": 115,
                   "nodeType": "ExpressionStatement",
-                  "src": "1807:17:1"
+                  "src": "1504:17:1"
                 },
                 {
                   "expression": {
@@ -3144,7 +3144,7 @@
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 80,
-                        "src": "1827:10:1",
+                        "src": "1524:10:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_uint256_$_t_struct$_Candidate_$65_storage_$",
                           "typeString": "mapping(uint256 => struct Election.Candidate storage ref)"
@@ -3158,7 +3158,7 @@
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 94,
-                        "src": "1838:15:1",
+                        "src": "1535:15:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
@@ -3169,7 +3169,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "1827:27:1",
+                      "src": "1524:27:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_struct$_Candidate_$65_storage",
                         "typeString": "struct Election.Candidate storage ref"
@@ -3187,7 +3187,7 @@
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 94,
-                          "src": "1867:15:1",
+                          "src": "1564:15:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
@@ -3200,7 +3200,7 @@
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 110,
-                          "src": "1884:5:1",
+                          "src": "1581:5:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_string_memory_ptr",
                             "typeString": "string memory"
@@ -3216,7 +3216,7 @@
                           "kind": "number",
                           "lValueRequested": false,
                           "nodeType": "Literal",
-                          "src": "1891:1:1",
+                          "src": "1588:1:1",
                           "subdenomination": null,
                           "typeDescriptions": {
                             "typeIdentifier": "t_rational_0_by_1",
@@ -3245,7 +3245,7 @@
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 65,
-                        "src": "1857:9:1",
+                        "src": "1554:9:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_type$_t_struct$_Candidate_$65_storage_ptr_$",
                           "typeString": "type(struct Election.Candidate storage pointer)"
@@ -3259,13 +3259,13 @@
                       "lValueRequested": false,
                       "names": [],
                       "nodeType": "FunctionCall",
-                      "src": "1857:36:1",
+                      "src": "1554:36:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_struct$_Candidate_$65_memory",
                         "typeString": "struct Election.Candidate memory"
                       }
                     },
-                    "src": "1827:66:1",
+                    "src": "1524:66:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_struct$_Candidate_$65_storage",
                       "typeString": "struct Election.Candidate storage ref"
@@ -3273,7 +3273,7 @@
                   },
                   "id": 125,
                   "nodeType": "ExpressionStatement",
-                  "src": "1827:66:1"
+                  "src": "1524:66:1"
                 }
               ]
             },
@@ -3295,7 +3295,7 @@
                   "name": "_name",
                   "nodeType": "VariableDeclaration",
                   "scope": 127,
-                  "src": "1782:12:1",
+                  "src": "1479:12:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -3306,7 +3306,7 @@
                     "id": 109,
                     "name": "string",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1782:6:1",
+                    "src": "1479:6:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_string_storage_ptr",
                       "typeString": "string"
@@ -3316,17 +3316,17 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "1781:14:1"
+              "src": "1478:14:1"
             },
             "payable": false,
             "returnParameters": {
               "id": 112,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "1804:0:1"
+              "src": "1501:0:1"
             },
             "scope": 225,
-            "src": "1760:137:1",
+            "src": "1457:137:1",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "private"
@@ -3335,7 +3335,7 @@
             "body": {
               "id": 170,
               "nodeType": "Block",
-              "src": "1985:351:1",
+              "src": "1682:351:1",
               "statements": [
                 {
                   "expression": {
@@ -3374,7 +3374,7 @@
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
                                 "referencedDeclaration": 84,
-                                "src": "1996:6:1",
+                                "src": "1693:6:1",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
                                   "typeString": "mapping(address => struct Election.Voter storage ref)"
@@ -3390,7 +3390,7 @@
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
                                   "referencedDeclaration": 240,
-                                  "src": "2003:3:1",
+                                  "src": "1700:3:1",
                                   "typeDescriptions": {
                                     "typeIdentifier": "t_magic_message",
                                     "typeString": "msg"
@@ -3404,7 +3404,7 @@
                                 "memberName": "sender",
                                 "nodeType": "MemberAccess",
                                 "referencedDeclaration": null,
-                                "src": "2003:10:1",
+                                "src": "1700:10:1",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_address",
                                   "typeString": "address"
@@ -3415,7 +3415,7 @@
                               "isPure": false,
                               "lValueRequested": false,
                               "nodeType": "IndexAccess",
-                              "src": "1996:18:1",
+                              "src": "1693:18:1",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_struct$_Voter_$76_storage",
                                 "typeString": "struct Election.Voter storage ref"
@@ -3429,7 +3429,7 @@
                             "memberName": "eligibility",
                             "nodeType": "MemberAccess",
                             "referencedDeclaration": 69,
-                            "src": "1996:30:1",
+                            "src": "1693:30:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_bool",
                               "typeString": "bool"
@@ -3447,7 +3447,7 @@
                             "kind": "bool",
                             "lValueRequested": false,
                             "nodeType": "Literal",
-                            "src": "2030:5:1",
+                            "src": "1727:5:1",
                             "subdenomination": null,
                             "typeDescriptions": {
                               "typeIdentifier": "t_bool",
@@ -3455,7 +3455,7 @@
                             },
                             "value": "false"
                           },
-                          "src": "1996:39:1",
+                          "src": "1693:39:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
@@ -3485,7 +3485,7 @@
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
                                 "referencedDeclaration": 84,
-                                "src": "2039:6:1",
+                                "src": "1736:6:1",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
                                   "typeString": "mapping(address => struct Election.Voter storage ref)"
@@ -3501,7 +3501,7 @@
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
                                   "referencedDeclaration": 240,
-                                  "src": "2046:3:1",
+                                  "src": "1743:3:1",
                                   "typeDescriptions": {
                                     "typeIdentifier": "t_magic_message",
                                     "typeString": "msg"
@@ -3515,7 +3515,7 @@
                                 "memberName": "sender",
                                 "nodeType": "MemberAccess",
                                 "referencedDeclaration": null,
-                                "src": "2046:10:1",
+                                "src": "1743:10:1",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_address",
                                   "typeString": "address"
@@ -3526,7 +3526,7 @@
                               "isPure": false,
                               "lValueRequested": false,
                               "nodeType": "IndexAccess",
-                              "src": "2039:18:1",
+                              "src": "1736:18:1",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_struct$_Voter_$76_storage",
                                 "typeString": "struct Election.Voter storage ref"
@@ -3540,7 +3540,7 @@
                             "memberName": "NID",
                             "nodeType": "MemberAccess",
                             "referencedDeclaration": 67,
-                            "src": "2039:22:1",
+                            "src": "1736:22:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
@@ -3555,19 +3555,19 @@
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
                             "referencedDeclaration": 129,
-                            "src": "2065:11:1",
+                            "src": "1762:11:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
                             }
                           },
-                          "src": "2039:37:1",
+                          "src": "1736:37:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
                           }
                         },
-                        "src": "1996:80:1",
+                        "src": "1693:80:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
@@ -3589,7 +3589,7 @@
                         244
                       ],
                       "referencedDeclaration": 243,
-                      "src": "1988:7:1",
+                      "src": "1685:7:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
                         "typeString": "function (bool) pure"
@@ -3603,7 +3603,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1988:89:1",
+                    "src": "1685:89:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
@@ -3611,7 +3611,7 @@
                   },
                   "id": 149,
                   "nodeType": "ExpressionStatement",
-                  "src": "1988:89:1"
+                  "src": "1685:89:1"
                 },
                 {
                   "expression": {
@@ -3624,7 +3624,7 @@
                     "nodeType": "UnaryOperation",
                     "operator": "++",
                     "prefix": false,
-                    "src": "2167:13:1",
+                    "src": "1864:13:1",
                     "subExpression": {
                       "argumentTypes": null,
                       "id": 150,
@@ -3632,7 +3632,7 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 96,
-                      "src": "2167:11:1",
+                      "src": "1864:11:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
@@ -3645,7 +3645,7 @@
                   },
                   "id": 152,
                   "nodeType": "ExpressionStatement",
-                  "src": "2167:13:1"
+                  "src": "1864:13:1"
                 },
                 {
                   "expression": {
@@ -3664,7 +3664,7 @@
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 84,
-                        "src": "2183:6:1",
+                        "src": "1880:6:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
                           "typeString": "mapping(address => struct Election.Voter storage ref)"
@@ -3680,7 +3680,7 @@
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 240,
-                          "src": "2190:3:1",
+                          "src": "1887:3:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_magic_message",
                             "typeString": "msg"
@@ -3694,7 +3694,7 @@
                         "memberName": "sender",
                         "nodeType": "MemberAccess",
                         "referencedDeclaration": null,
-                        "src": "2190:10:1",
+                        "src": "1887:10:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
                           "typeString": "address"
@@ -3705,7 +3705,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "2183:18:1",
+                      "src": "1880:18:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_struct$_Voter_$76_storage",
                         "typeString": "struct Election.Voter storage ref"
@@ -3723,7 +3723,7 @@
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 129,
-                          "src": "2210:11:1",
+                          "src": "1907:11:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
@@ -3739,7 +3739,7 @@
                           "kind": "bool",
                           "lValueRequested": false,
                           "nodeType": "Literal",
-                          "src": "2222:4:1",
+                          "src": "1919:4:1",
                           "subdenomination": null,
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
@@ -3757,7 +3757,7 @@
                           "kind": "bool",
                           "lValueRequested": false,
                           "nodeType": "Literal",
-                          "src": "2227:5:1",
+                          "src": "1924:5:1",
                           "subdenomination": null,
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
@@ -3775,7 +3775,7 @@
                           "kind": "number",
                           "lValueRequested": false,
                           "nodeType": "Literal",
-                          "src": "2233:1:1",
+                          "src": "1930:1:1",
                           "subdenomination": null,
                           "typeDescriptions": {
                             "typeIdentifier": "t_rational_0_by_1",
@@ -3793,7 +3793,7 @@
                           "kind": "number",
                           "lValueRequested": false,
                           "nodeType": "Literal",
-                          "src": "2235:1:1",
+                          "src": "1932:1:1",
                           "subdenomination": null,
                           "typeDescriptions": {
                             "typeIdentifier": "t_rational_0_by_1",
@@ -3830,7 +3830,7 @@
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 76,
-                        "src": "2204:5:1",
+                        "src": "1901:5:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_type$_t_struct$_Voter_$76_storage_ptr_$",
                           "typeString": "type(struct Election.Voter storage pointer)"
@@ -3844,13 +3844,13 @@
                       "lValueRequested": false,
                       "names": [],
                       "nodeType": "FunctionCall",
-                      "src": "2204:33:1",
+                      "src": "1901:33:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_struct$_Voter_$76_memory",
                         "typeString": "struct Election.Voter memory"
                       }
                     },
-                    "src": "2183:54:1",
+                    "src": "1880:54:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_struct$_Voter_$76_storage",
                       "typeString": "struct Election.Voter storage ref"
@@ -3858,7 +3858,7 @@
                   },
                   "id": 165,
                   "nodeType": "ExpressionStatement",
-                  "src": "2183:54:1"
+                  "src": "1880:54:1"
                 },
                 {
                   "eventCall": {
@@ -3871,7 +3871,7 @@
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 129,
-                        "src": "2320:11:1",
+                        "src": "2017:11:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
@@ -3890,7 +3890,7 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 92,
-                      "src": "2311:8:1",
+                      "src": "2008:8:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_event_nonpayable$_t_uint256_$returns$__$",
                         "typeString": "function (uint256)"
@@ -3904,7 +3904,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "2311:21:1",
+                    "src": "2008:21:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
@@ -3912,7 +3912,7 @@
                   },
                   "id": 169,
                   "nodeType": "EmitStatement",
-                  "src": "2306:26:1"
+                  "src": "2003:26:1"
                 }
               ]
             },
@@ -3934,7 +3934,7 @@
                   "name": "_nationalID",
                   "nodeType": "VariableDeclaration",
                   "scope": 171,
-                  "src": "1960:16:1",
+                  "src": "1657:16:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -3945,7 +3945,7 @@
                     "id": 128,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1960:4:1",
+                    "src": "1657:4:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -3955,17 +3955,17 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "1959:18:1"
+              "src": "1656:18:1"
             },
             "payable": false,
             "returnParameters": {
               "id": 131,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "1985:0:1"
+              "src": "1682:0:1"
             },
             "scope": 225,
-            "src": "1942:394:1",
+            "src": "1639:394:1",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
@@ -3974,7 +3974,7 @@
             "body": {
               "id": 223,
               "nodeType": "Block",
-              "src": "2380:564:1",
+              "src": "2077:564:1",
               "statements": [
                 {
                   "expression": {
@@ -4002,7 +4002,7 @@
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
                               "referencedDeclaration": 84,
-                              "src": "2436:6:1",
+                              "src": "2133:6:1",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
                                 "typeString": "mapping(address => struct Election.Voter storage ref)"
@@ -4018,7 +4018,7 @@
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
                                 "referencedDeclaration": 240,
-                                "src": "2443:3:1",
+                                "src": "2140:3:1",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_magic_message",
                                   "typeString": "msg"
@@ -4032,7 +4032,7 @@
                               "memberName": "sender",
                               "nodeType": "MemberAccess",
                               "referencedDeclaration": null,
-                              "src": "2443:10:1",
+                              "src": "2140:10:1",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_address",
                                 "typeString": "address"
@@ -4043,7 +4043,7 @@
                             "isPure": false,
                             "lValueRequested": false,
                             "nodeType": "IndexAccess",
-                            "src": "2436:18:1",
+                            "src": "2133:18:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_struct$_Voter_$76_storage",
                               "typeString": "struct Election.Voter storage ref"
@@ -4057,7 +4057,7 @@
                           "memberName": "eligibility",
                           "nodeType": "MemberAccess",
                           "referencedDeclaration": 69,
-                          "src": "2436:30:1",
+                          "src": "2133:30:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
@@ -4075,7 +4075,7 @@
                           "kind": "bool",
                           "lValueRequested": false,
                           "nodeType": "Literal",
-                          "src": "2470:4:1",
+                          "src": "2167:4:1",
                           "subdenomination": null,
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
@@ -4083,7 +4083,7 @@
                           },
                           "value": "true"
                         },
-                        "src": "2436:38:1",
+                        "src": "2133:38:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
@@ -4105,7 +4105,7 @@
                         244
                       ],
                       "referencedDeclaration": 243,
-                      "src": "2428:7:1",
+                      "src": "2125:7:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
                         "typeString": "function (bool) pure"
@@ -4119,7 +4119,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "2428:47:1",
+                    "src": "2125:47:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
@@ -4127,7 +4127,7 @@
                   },
                   "id": 185,
                   "nodeType": "ExpressionStatement",
-                  "src": "2428:47:1"
+                  "src": "2125:47:1"
                 },
                 {
                   "expression": {
@@ -4143,7 +4143,7 @@
                         "nodeType": "UnaryOperation",
                         "operator": "!",
                         "prefix": true,
-                        "src": "2547:28:1",
+                        "src": "2244:28:1",
                         "subExpression": {
                           "argumentTypes": null,
                           "expression": {
@@ -4155,7 +4155,7 @@
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
                               "referencedDeclaration": 84,
-                              "src": "2548:6:1",
+                              "src": "2245:6:1",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
                                 "typeString": "mapping(address => struct Election.Voter storage ref)"
@@ -4171,7 +4171,7 @@
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
                                 "referencedDeclaration": 240,
-                                "src": "2555:3:1",
+                                "src": "2252:3:1",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_magic_message",
                                   "typeString": "msg"
@@ -4185,7 +4185,7 @@
                               "memberName": "sender",
                               "nodeType": "MemberAccess",
                               "referencedDeclaration": null,
-                              "src": "2555:10:1",
+                              "src": "2252:10:1",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_address",
                                 "typeString": "address"
@@ -4196,7 +4196,7 @@
                             "isPure": false,
                             "lValueRequested": false,
                             "nodeType": "IndexAccess",
-                            "src": "2548:18:1",
+                            "src": "2245:18:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_struct$_Voter_$76_storage",
                               "typeString": "struct Election.Voter storage ref"
@@ -4210,7 +4210,7 @@
                           "memberName": "hasVoted",
                           "nodeType": "MemberAccess",
                           "referencedDeclaration": 71,
-                          "src": "2548:27:1",
+                          "src": "2245:27:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
@@ -4237,7 +4237,7 @@
                         244
                       ],
                       "referencedDeclaration": 243,
-                      "src": "2539:7:1",
+                      "src": "2236:7:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
                         "typeString": "function (bool) pure"
@@ -4251,7 +4251,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "2539:37:1",
+                    "src": "2236:37:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
@@ -4259,7 +4259,7 @@
                   },
                   "id": 194,
                   "nodeType": "ExpressionStatement",
-                  "src": "2539:37:1"
+                  "src": "2236:37:1"
                 },
                 {
                   "expression": {
@@ -4294,7 +4294,7 @@
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
                             "referencedDeclaration": 173,
-                            "src": "2635:12:1",
+                            "src": "2332:12:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
@@ -4312,7 +4312,7 @@
                             "kind": "number",
                             "lValueRequested": false,
                             "nodeType": "Literal",
-                            "src": "2650:1:1",
+                            "src": "2347:1:1",
                             "subdenomination": null,
                             "typeDescriptions": {
                               "typeIdentifier": "t_rational_0_by_1",
@@ -4320,7 +4320,7 @@
                             },
                             "value": "0"
                           },
-                          "src": "2635:16:1",
+                          "src": "2332:16:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
@@ -4346,7 +4346,7 @@
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
                             "referencedDeclaration": 173,
-                            "src": "2655:12:1",
+                            "src": "2352:12:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
@@ -4361,19 +4361,19 @@
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
                             "referencedDeclaration": 94,
-                            "src": "2671:15:1",
+                            "src": "2368:15:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
                             }
                           },
-                          "src": "2655:31:1",
+                          "src": "2352:31:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
                           }
                         },
-                        "src": "2635:51:1",
+                        "src": "2332:51:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
@@ -4395,7 +4395,7 @@
                         244
                       ],
                       "referencedDeclaration": 243,
-                      "src": "2627:7:1",
+                      "src": "2324:7:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
                         "typeString": "function (bool) pure"
@@ -4409,7 +4409,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "2627:60:1",
+                    "src": "2324:60:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
@@ -4417,7 +4417,7 @@
                   },
                   "id": 204,
                   "nodeType": "ExpressionStatement",
-                  "src": "2627:60:1"
+                  "src": "2324:60:1"
                 },
                 {
                   "expression": {
@@ -4438,7 +4438,7 @@
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 84,
-                          "src": "2740:6:1",
+                          "src": "2437:6:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
                             "typeString": "mapping(address => struct Election.Voter storage ref)"
@@ -4454,7 +4454,7 @@
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
                             "referencedDeclaration": 240,
-                            "src": "2747:3:1",
+                            "src": "2444:3:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_magic_message",
                               "typeString": "msg"
@@ -4468,7 +4468,7 @@
                           "memberName": "sender",
                           "nodeType": "MemberAccess",
                           "referencedDeclaration": null,
-                          "src": "2747:10:1",
+                          "src": "2444:10:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -4479,7 +4479,7 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "2740:18:1",
+                        "src": "2437:18:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_struct$_Voter_$76_storage",
                           "typeString": "struct Election.Voter storage ref"
@@ -4493,7 +4493,7 @@
                       "memberName": "hasVoted",
                       "nodeType": "MemberAccess",
                       "referencedDeclaration": 71,
-                      "src": "2740:27:1",
+                      "src": "2437:27:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
                         "typeString": "bool"
@@ -4511,7 +4511,7 @@
                       "kind": "bool",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "2770:4:1",
+                      "src": "2467:4:1",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
@@ -4519,7 +4519,7 @@
                       },
                       "value": "true"
                     },
-                    "src": "2740:34:1",
+                    "src": "2437:34:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
@@ -4527,7 +4527,7 @@
                   },
                   "id": 212,
                   "nodeType": "ExpressionStatement",
-                  "src": "2740:34:1"
+                  "src": "2437:34:1"
                 },
                 {
                   "expression": {
@@ -4540,7 +4540,7 @@
                     "nodeType": "UnaryOperation",
                     "operator": "++",
                     "prefix": false,
-                    "src": "2827:36:1",
+                    "src": "2524:36:1",
                     "subExpression": {
                       "argumentTypes": null,
                       "expression": {
@@ -4552,7 +4552,7 @@
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 80,
-                          "src": "2827:10:1",
+                          "src": "2524:10:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_uint256_$_t_struct$_Candidate_$65_storage_$",
                             "typeString": "mapping(uint256 => struct Election.Candidate storage ref)"
@@ -4566,7 +4566,7 @@
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 173,
-                          "src": "2838:12:1",
+                          "src": "2535:12:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
@@ -4577,7 +4577,7 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "2827:24:1",
+                        "src": "2524:24:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_struct$_Candidate_$65_storage",
                           "typeString": "struct Election.Candidate storage ref"
@@ -4591,7 +4591,7 @@
                       "memberName": "voteCount",
                       "nodeType": "MemberAccess",
                       "referencedDeclaration": 64,
-                      "src": "2827:34:1",
+                      "src": "2524:34:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
@@ -4604,7 +4604,7 @@
                   },
                   "id": 218,
                   "nodeType": "ExpressionStatement",
-                  "src": "2827:36:1"
+                  "src": "2524:36:1"
                 },
                 {
                   "eventCall": {
@@ -4617,7 +4617,7 @@
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 173,
-                        "src": "2923:12:1",
+                        "src": "2620:12:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
@@ -4636,7 +4636,7 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 88,
-                      "src": "2912:10:1",
+                      "src": "2609:10:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_event_nonpayable$_t_uint256_$returns$__$",
                         "typeString": "function (uint256)"
@@ -4650,7 +4650,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "2912:24:1",
+                    "src": "2609:24:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
@@ -4658,7 +4658,7 @@
                   },
                   "id": 222,
                   "nodeType": "EmitStatement",
-                  "src": "2907:29:1"
+                  "src": "2604:29:1"
                 }
               ]
             },
@@ -4680,7 +4680,7 @@
                   "name": "_candidateId",
                   "nodeType": "VariableDeclaration",
                   "scope": 224,
-                  "src": "2354:17:1",
+                  "src": "2051:17:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -4691,7 +4691,7 @@
                     "id": 172,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
-                    "src": "2354:4:1",
+                    "src": "2051:4:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -4701,27 +4701,27 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "2353:19:1"
+              "src": "2050:19:1"
             },
             "payable": false,
             "returnParameters": {
               "id": 175,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "2380:0:1"
+              "src": "2077:0:1"
             },
             "scope": 225,
-            "src": "2340:604:1",
+            "src": "2037:604:1",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
           }
         ],
         "scope": 226,
-        "src": "28:2919:1"
+        "src": "28:2616:1"
       }
     ],
-    "src": "0:2949:1"
+    "src": "0:2646:1"
   },
   "compiler": {
     "name": "solc",
@@ -4758,12 +4758,12 @@
         }
       },
       "links": {},
-      "address": "0x23E8c302F28aceb4BbC15C184dBf1F1Ccce7da4d",
-      "transactionHash": "0xf0a6ee43388a1ed487428a8d4ff1076ad00facfcb35431b19e3d4c6f483e26a9"
+      "address": "0x6017aa4De7F59FADB82336eCe743424fb51F3Dc8",
+      "transactionHash": "0x3192e5cd46fdd5916f130975a20f8afc3a51a781bb44fa0c27d073d10394440e"
     }
   },
   "schemaVersion": "3.0.22",
-  "updatedAt": "2020-08-07T21:10:55.882Z",
+  "updatedAt": "2020-08-08T16:38:26.053Z",
   "networkType": "ethereum",
   "devdoc": {
     "methods": {}

--- a/build/contracts/Election.json
+++ b/build/contracts/Election.json
@@ -44,6 +44,20 @@
     },
     {
       "constant": true,
+      "inputs": [],
+      "name": "votersCount",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
       "inputs": [
         {
           "name": "",
@@ -53,8 +67,24 @@
       "name": "voters",
       "outputs": [
         {
-          "name": "",
+          "name": "NID",
+          "type": "uint256"
+        },
+        {
+          "name": "eligibility",
           "type": "bool"
+        },
+        {
+          "name": "hasVoted",
+          "type": "bool"
+        },
+        {
+          "name": "blindedVote",
+          "type": "uint256"
+        },
+        {
+          "name": "signedBlindedVote",
+          "type": "uint256"
         }
       ],
       "payable": false,
@@ -83,6 +113,20 @@
       "constant": false,
       "inputs": [
         {
+          "name": "_nationalID",
+          "type": "uint256"
+        }
+      ],
+      "name": "addVoter",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
           "name": "_candidateId",
           "type": "uint256"
         }
@@ -94,21 +138,21 @@
       "type": "function"
     }
   ],
-  "metadata": "{\"compiler\":{\"version\":\"0.4.23+commit.124ca40d\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"constant\":false,\"inputs\":[{\"name\":\"_candidateId\",\"type\":\"uint256\"}],\"name\":\"vote\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"candidatesCount\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"candidates\",\"outputs\":[{\"name\":\"id\",\"type\":\"uint256\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"voteCount\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"address\"}],\"name\":\"voters\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"_candidateId\",\"type\":\"uint256\"}],\"name\":\"votedEvent\",\"type\":\"event\"}],\"devdoc\":{\"methods\":{}},\"userdoc\":{\"methods\":{}}},\"settings\":{\"compilationTarget\":{\"/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/election.sol\":\"Election\"},\"evmVersion\":\"byzantium\",\"libraries\":{},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/election.sol\":{\"keccak256\":\"0x5e4d33112051aa5e6f573866dda72ecb0c3929e5118d81a68d0b30b8d7acd4c2\",\"urls\":[\"bzzr://345bd561af75b7ac2b2a1b895dda7d2faad3edd25de1a3e21939ca69dc31ec80\"]}},\"version\":1}",
-  "bytecode": "0x608060405234801561001057600080fd5b5061005e6040805190810160405280600b81526020017f43616e64696461746520310000000000000000000000000000000000000000008152506100b0640100000000026401000000009004565b6100ab6040805190810160405280600b81526020017f43616e64696461746520320000000000000000000000000000000000000000008152506100b0640100000000026401000000009004565b6101d1565b60026000815480929190600101919050555060606040519081016040528060025481526020018281526020016000815250600080600254815260200190815260200160002060008201518160000155602082015181600101908051906020019061011b92919061012c565b506040820151816002015590505050565b828054600181600116156101000203166002900490600052602060002090601f016020900481019282601f1061016d57805160ff191683800117855561019b565b8280016001018555821561019b579182015b8281111561019a57825182559160200191906001019061017f565b5b5090506101a891906101ac565b5090565b6101ce91905b808211156101ca5760008160009055506001016101b2565b5090565b90565b610404806101e06000396000f300608060405260043610610062576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630121b93f146100675780632d35a8a2146100945780633477ee2e146100bf578063a3ec138d14610173575b600080fd5b34801561007357600080fd5b50610092600480360381019080803590602001909291905050506101ce565b005b3480156100a057600080fd5b506100a96102f0565b6040518082815260200191505060405180910390f35b3480156100cb57600080fd5b506100ea600480360381019080803590602001909291905050506102f6565b6040518084815260200180602001838152602001828103825284818151815260200191508051906020019080838360005b8381101561013657808201518184015260208101905061011b565b50505050905090810190601f1680156101635780820380516001836020036101000a031916815260200191505b5094505050505060405180910390f35b34801561017f57600080fd5b506101b4600480360381019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506103b8565b604051808215151515815260200191505060405180910390f35b600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060009054906101000a900460ff1615151561022757600080fd5b60008111801561023957506002548111155b151561024457600080fd5b60018060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060006101000a81548160ff02191690831515021790555060008082815260200190815260200160002060020160008154809291906001019190505550807ffff3c900d938d21d0990d786e819f29b8d05c1ef587b462b939609625b684b1660405160405180910390a250565b60025481565b6000602052806000526040600020600091509050806000015490806001018054600181600116156101000203166002900480601f0160208091040260200160405190810160405280929190818152602001828054600181600116156101000203166002900480156103a85780601f1061037d576101008083540402835291602001916103a8565b820191906000526020600020905b81548152906001019060200180831161038b57829003601f168201915b5050505050908060020154905083565b60016020528060005260406000206000915054906101000a900460ff16815600a165627a7a72305820ef2911550ec9c64cd61d672e019e98979d964dcea5f2ff3f0b597f1b4f3359c10029",
-  "deployedBytecode": "0x608060405260043610610062576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630121b93f146100675780632d35a8a2146100945780633477ee2e146100bf578063a3ec138d14610173575b600080fd5b34801561007357600080fd5b50610092600480360381019080803590602001909291905050506101ce565b005b3480156100a057600080fd5b506100a96102f0565b6040518082815260200191505060405180910390f35b3480156100cb57600080fd5b506100ea600480360381019080803590602001909291905050506102f6565b6040518084815260200180602001838152602001828103825284818151815260200191508051906020019080838360005b8381101561013657808201518184015260208101905061011b565b50505050905090810190601f1680156101635780820380516001836020036101000a031916815260200191505b5094505050505060405180910390f35b34801561017f57600080fd5b506101b4600480360381019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506103b8565b604051808215151515815260200191505060405180910390f35b600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060009054906101000a900460ff1615151561022757600080fd5b60008111801561023957506002548111155b151561024457600080fd5b60018060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060006101000a81548160ff02191690831515021790555060008082815260200190815260200160002060020160008154809291906001019190505550807ffff3c900d938d21d0990d786e819f29b8d05c1ef587b462b939609625b684b1660405160405180910390a250565b60025481565b6000602052806000526040600020600091509050806000015490806001018054600181600116156101000203166002900480601f0160208091040260200160405190810160405280929190818152602001828054600181600116156101000203166002900480156103a85780601f1061037d576101008083540402835291602001916103a8565b820191906000526020600020905b81548152906001019060200180831161038b57829003601f168201915b5050505050908060020154905083565b60016020528060005260406000206000915054906101000a900460ff16815600a165627a7a72305820ef2911550ec9c64cd61d672e019e98979d964dcea5f2ff3f0b597f1b4f3359c10029",
-  "sourceMap": "27:1138:1:-;;;445:87;8:9:-1;5:2;;;30:1;27;20:12;5:2;445:87:1;470:27;;;;;;;;;;;;;;;;;;;:12;;;:27;;;:::i;:::-;501;;;;;;;;;;;;;;;;;;;:12;;;:27;;;:::i;:::-;27:1138;;536:137;583:15;;:17;;;;;;;;;;;;;633:36;;;;;;;;;643:15;;633:36;;;;660:5;633:36;;;;667:1;633:36;;;603:10;:27;614:15;;603:27;;;;;;;;;;;:66;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;536:137;:::o;27:1138::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;:::o;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;:::o;:::-;;;;;;;",
-  "deployedSourceMap": "27:1138:1:-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;678:484;;8:9:-1;5:2;;;30:1;27;20:12;5:2;678:484:1;;;;;;;;;;;;;;;;;;;;;;;;;;413:27;;8:9:-1;5:2;;;30:1;27;20:12;5:2;413:27:1;;;;;;;;;;;;;;;;;;;;;;;166:44;;8:9:-1;5:2;;;30:1;27;20:12;5:2;166:44:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;23:1:-1;8:100;33:3;30:1;27:10;8:100;;;99:1;94:3;90:11;84:18;80:1;75:3;71:11;64:39;52:2;49:1;45:10;40:15;;8:100;;;12:14;166:44:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;250:38;;8:9:-1;5:2;;;30:1;27;20:12;5:2;250:38:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;678:484;789:6;:18;796:10;789:18;;;;;;;;;;;;;;;;;;;;;;;;;788:19;780:28;;;;;;;;882:1;867:12;:16;:51;;;;;903:15;;887:12;:31;;867:51;859:60;;;;;;;;993:4;972:6;:18;979:10;972:18;;;;;;;;;;;;;;;;:25;;;;;;;;;;;;;;;;;;1050:10;:24;1061:12;1050:24;;;;;;;;;;;:34;;;:36;;;;;;;;;;;;;1141:12;1130:24;;;;;;;;;;678:484;:::o;413:27::-;;;;:::o;166:44::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::o;250:38::-;;;;;;;;;;;;;;;;;;;;;;:::o",
-  "source": "pragma solidity ^0.4.2;\r\n\r\ncontract Election {\r\n// Model a Candidate\r\n struct Candidate {\r\n\tuint id;\r\n\tstring name;\r\n\tuint voteCount;\r\n}\r\n\r\n// Read/write candidates\r\nmapping(uint => Candidate) public candidates;\r\n\r\n// Store accounts that have voted\r\nmapping(address => bool) public voters;\r\n\r\n// event for logging successful votes\r\nevent votedEvent(\r\n  uint indexed _candidateId\r\n  );\r\n// Store Candidates Count\r\nuint public candidatesCount;\r\n\r\nconstructor() public {\r\n\taddCandidate(\"Candidate 1\");\r\n\taddCandidate(\"Candidate 2\");\r\n}\r\n\r\nfunction addCandidate(string _name) private {\r\ncandidatesCount++;\r\ncandidates[candidatesCount] = Candidate(candidatesCount, _name, 0);\r\n}\r\n\r\n function vote(uint _candidateId) public {\r\n        // require that they haven't voted before\r\n        require(!voters[msg.sender]);\r\n\r\n        // require a valid candidate\r\n        require(_candidateId > 0 && _candidateId <= candidatesCount);\r\n\r\n        // record that voter has voted\r\n        voters[msg.sender] = true;\r\n\r\n        // update candidate vote Count\r\n        candidates[_candidateId].voteCount++;\r\n\r\n        //trigger voted event\r\n        votedEvent(_candidateId);\r\n    }\r\n}\r\n",
+  "metadata": "{\"compiler\":{\"version\":\"0.4.23+commit.124ca40d\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"constant\":false,\"inputs\":[{\"name\":\"_candidateId\",\"type\":\"uint256\"}],\"name\":\"vote\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"candidatesCount\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"candidates\",\"outputs\":[{\"name\":\"id\",\"type\":\"uint256\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"voteCount\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"votersCount\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"address\"}],\"name\":\"voters\",\"outputs\":[{\"name\":\"NID\",\"type\":\"uint256\"},{\"name\":\"eligibility\",\"type\":\"bool\"},{\"name\":\"hasVoted\",\"type\":\"bool\"},{\"name\":\"blindedVote\",\"type\":\"uint256\"},{\"name\":\"signedBlindedVote\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_nationalID\",\"type\":\"uint256\"}],\"name\":\"addVoter\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"_candidateId\",\"type\":\"uint256\"}],\"name\":\"votedEvent\",\"type\":\"event\"}],\"devdoc\":{\"methods\":{}},\"userdoc\":{\"methods\":{}}},\"settings\":{\"compilationTarget\":{\"/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/election.sol\":\"Election\"},\"evmVersion\":\"byzantium\",\"libraries\":{},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/election.sol\":{\"keccak256\":\"0x175a8bf88a9e8b4b390e68c9c3e9b15c7095a4ddfbc5cd133569aa22b7140195\",\"urls\":[\"bzzr://b0a2c16899a623fbe13bbb31fbde73bb9476ad3dd9846d3605a38f51cf90459c\"]}},\"version\":1}",
+  "bytecode": "0x608060405234801561001057600080fd5b5061005e6040805190810160405280600b81526020017f43616e64696461746520310000000000000000000000000000000000000000008152506100e2640100000000026401000000009004565b6100ab6040805190810160405280600b81526020017f43616e64696461746520320000000000000000000000000000000000000000008152506100e2640100000000026401000000009004565b6100c4606461015e640100000000026401000000009004565b6100dd60c861015e640100000000026401000000009004565b6102e8565b60026000815480929190600101919050555060606040519081016040528060025481526020018281526020016000815250600080600254815260200190815260200160002060008201518160000155602082015181600101908051906020019061014d929190610243565b506040820151816002015590505050565b60036000815480929190600101919050555060a060405190810160405280828152602001600115158152602001600015158152602001600081526020016000815250600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000820151816000015560208201518160010160006101000a81548160ff02191690831515021790555060408201518160010160016101000a81548160ff021916908315150217905550606082015181600201556080820151816003015590505050565b828054600181600116156101000203166002900490600052602060002090601f016020900481019282601f1061028457805160ff19168380011785556102b2565b828001600101855582156102b2579182015b828111156102b1578251825591602001919060010190610296565b5b5090506102bf91906102c3565b5090565b6102e591905b808211156102e15760008160009055506001016102c9565b5090565b90565b610615806102f76000396000f300608060405260043610610078576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630121b93f1461007d5780632d35a8a2146100aa5780633477ee2e146100d557806398c0793814610189578063a3ec138d146101b4578063d8f7a0bb1461022f575b600080fd5b34801561008957600080fd5b506100a86004803603810190808035906020019092919050505061025c565b005b3480156100b657600080fd5b506100bf6103e6565b6040518082815260200191505060405180910390f35b3480156100e157600080fd5b50610100600480360381019080803590602001909291905050506103ec565b6040518084815260200180602001838152602001828103825284818151815260200191508051906020019080838360005b8381101561014c578082015181840152602081019050610131565b50505050905090810190601f1680156101795780820380516001836020036101000a031916815260200191505b5094505050505060405180910390f35b34801561019557600080fd5b5061019e6104ae565b6040518082815260200191505060405180910390f35b3480156101c057600080fd5b506101f5600480360381019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506104b4565b6040518086815260200185151515158152602001841515151581526020018381526020018281526020019550505050505060405180910390f35b34801561023b57600080fd5b5061025a60048036038101908080359060200190929190505050610504565b005b60011515600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160009054906101000a900460ff1615151415156102be57600080fd5b600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160019054906101000a900460ff1615151561031a57600080fd5b60008111801561032c57506002548111155b151561033757600080fd5b60018060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160016101000a81548160ff02191690831515021790555060008082815260200190815260200160002060020160008154809291906001019190505550807ffff3c900d938d21d0990d786e819f29b8d05c1ef587b462b939609625b684b1660405160405180910390a250565b60025481565b6000602052806000526040600020600091509050806000015490806001018054600181600116156101000203166002900480601f01602080910402602001604051908101604052809291908181526020018280546001816001161561010002031660029004801561049e5780601f106104735761010080835404028352916020019161049e565b820191906000526020600020905b81548152906001019060200180831161048157829003601f168201915b5050505050908060020154905083565b60035481565b60016020528060005260406000206000915090508060000154908060010160009054906101000a900460ff16908060010160019054906101000a900460ff16908060020154908060030154905085565b60036000815480929190600101919050555060a060405190810160405280828152602001600115158152602001600015158152602001600081526020016000815250600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000820151816000015560208201518160010160006101000a81548160ff02191690831515021790555060408201518160010160016101000a81548160ff0219169083151502179055506060820151816002015560808201518160030155905050505600a165627a7a72305820839f1b2b60c267e5e5f52075160e568fd258c37cdf8f01985f30adab36fa3fb50029",
+  "deployedBytecode": "0x608060405260043610610078576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630121b93f1461007d5780632d35a8a2146100aa5780633477ee2e146100d557806398c0793814610189578063a3ec138d146101b4578063d8f7a0bb1461022f575b600080fd5b34801561008957600080fd5b506100a86004803603810190808035906020019092919050505061025c565b005b3480156100b657600080fd5b506100bf6103e6565b6040518082815260200191505060405180910390f35b3480156100e157600080fd5b50610100600480360381019080803590602001909291905050506103ec565b6040518084815260200180602001838152602001828103825284818151815260200191508051906020019080838360005b8381101561014c578082015181840152602081019050610131565b50505050905090810190601f1680156101795780820380516001836020036101000a031916815260200191505b5094505050505060405180910390f35b34801561019557600080fd5b5061019e6104ae565b6040518082815260200191505060405180910390f35b3480156101c057600080fd5b506101f5600480360381019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506104b4565b6040518086815260200185151515158152602001841515151581526020018381526020018281526020019550505050505060405180910390f35b34801561023b57600080fd5b5061025a60048036038101908080359060200190929190505050610504565b005b60011515600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160009054906101000a900460ff1615151415156102be57600080fd5b600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160019054906101000a900460ff1615151561031a57600080fd5b60008111801561032c57506002548111155b151561033757600080fd5b60018060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060010160016101000a81548160ff02191690831515021790555060008082815260200190815260200160002060020160008154809291906001019190505550807ffff3c900d938d21d0990d786e819f29b8d05c1ef587b462b939609625b684b1660405160405180910390a250565b60025481565b6000602052806000526040600020600091509050806000015490806001018054600181600116156101000203166002900480601f01602080910402602001604051908101604052809291908181526020018280546001816001161561010002031660029004801561049e5780601f106104735761010080835404028352916020019161049e565b820191906000526020600020905b81548152906001019060200180831161048157829003601f168201915b5050505050908060020154905083565b60035481565b60016020528060005260406000206000915090508060000154908060010160009054906101000a900460ff16908060010160019054906101000a900460ff16908060020154908060030154905085565b60036000815480929190600101919050555060a060405190810160405280828152602001600115158152602001600015158152602001600081526020016000815250600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000820151816000015560208201518160010160006101000a81548160ff02191690831515021790555060408201518160010160016101000a81548160ff0219169083151502179055506060820151816002015560808201518160030155905050505600a165627a7a72305820839f1b2b60c267e5e5f52075160e568fd258c37cdf8f01985f30adab36fa3fb50029",
+  "sourceMap": "27:2070:1:-;;;928:136;8:9:-1;5:2;;;30:1;27;20:12;5:2;928:136:1;953:27;;;;;;;;;;;;;;;;;;;:12;;;:27;;;:::i;:::-;984;;;;;;;;;;;;;;;;;;;:12;;;:27;;;:::i;:::-;1016:13;1025:3;1016:8;;;:13;;;:::i;:::-;1047;1056:3;1047:8;;;:13;;;:::i;:::-;27:2070;;1118:137;1165:15;;:17;;;;;;;;;;;;;1215:36;;;;;;;;;1225:15;;1215:36;;;;1242:5;1215:36;;;;1249:1;1215:36;;;1185:10;:27;1196:15;;1185:27;;;;;;;;;;;:66;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;1118:137;:::o;1300:186::-;1346:11;;:13;;;;;;;;;;;;;1383:33;;;;;;;;;1389:11;1383:33;;;;1401:4;1383:33;;;;;;1406:5;1383:33;;;;;;1412:1;1383:33;;;;1414:1;1383:33;;;1362:6;:18;1369:10;1362:18;;;;;;;;;;;;;;;:54;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1300:186;:::o;27:2070::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;:::o;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;:::o;:::-;;;;;;;",
+  "deployedSourceMap": "27:2070:1:-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1490:604;;8:9:-1;5:2;;;30:1;27;20:12;5:2;1490:604:1;;;;;;;;;;;;;;;;;;;;;;;;;;805:27;;8:9:-1;5:2;;;30:1;27;20:12;5:2;805:27:1;;;;;;;;;;;;;;;;;;;;;;;557:44;;8:9:-1;5:2;;;30:1;27;20:12;5:2;557:44:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;23:1:-1;8:100;33:3;30:1;27:10;8:100;;;99:1;94:3;90:11;84:18;80:1;75:3;71:11;64:39;52:2;49:1;45:10;40:15;;8:100;;;12:14;557:44:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;869:23;;8:9:-1;5:2;;;30:1;27;20:12;5:2;869:23:1;;;;;;;;;;;;;;;;;;;;;;;641:39;;8:9:-1;5:2;;;30:1;27;20:12;5:2;641:39:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1300:186;;8:9:-1;5:2;;;30:1;27;20:12;5:2;1300:186:1;;;;;;;;;;;;;;;;;;;;;;;;;;1490:604;1620:4;1586:38;;:6;:18;1593:10;1586:18;;;;;;;;;;;;;;;:30;;;;;;;;;;;;:38;;;1578:47;;;;;;;;1698:6;:18;1705:10;1698:18;;;;;;;;;;;;;;;:27;;;;;;;;;;;;1697:28;1689:37;;;;;;;;1800:1;1785:12;:16;:51;;;;;1821:15;;1805:12;:31;;1785:51;1777:60;;;;;;;;1920:4;1890:6;:18;1897:10;1890:18;;;;;;;;;;;;;;;:27;;;:34;;;;;;;;;;;;;;;;;;1977:10;:24;1988:12;1977:24;;;;;;;;;;;:34;;;:36;;;;;;;;;;;;;2073:12;2062:24;;;;;;;;;;1490:604;:::o;805:27::-;;;;:::o;557:44::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::o;869:23::-;;;;:::o;641:39::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::o;1300:186::-;1346:11;;:13;;;;;;;;;;;;;1383:33;;;;;;;;;1389:11;1383:33;;;;1401:4;1383:33;;;;;;1406:5;1383:33;;;;;;1412:1;1383:33;;;;1414:1;1383:33;;;1362:6;:18;1369:10;1362:18;;;;;;;;;;;;;;;:54;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1300:186;:::o",
+  "source": "pragma solidity ^0.4.2;\r\n\r\ncontract Election {\r\n// Model a Candidate\r\n struct Candidate {\r\n\tuint id;\r\n\tstring name;\r\n\tuint voteCount;\r\n}\r\n//Modle a voter\r\nstruct Voter {\r\n  uint NID;     // govt issued national identification number of candidate\r\n  bool eligibility;      // stores the valid list of voters during registration\r\n  bool hasVoted;    // updates when vote is successfully casted on blockchain\r\n  uint blindedVote;    // stores each voter's hashed vote\r\n  uint signedBlindedVote;  // blind signature of casted vote\r\n}\r\n// Read/write candidates\r\nmapping(uint => Candidate) public candidates;\r\n\r\n// Store accounts that have voted\r\nmapping(address => Voter) public voters;\r\n\r\n// event for logging successful votes\r\nevent votedEvent(\r\n  uint indexed _candidateId\r\n  );\r\n// Store Candidates Count\r\nuint public candidatesCount;   // counter cache for candidates\r\nuint public votersCount;    // counter cache for voters\r\n\r\nconstructor() public {\r\n\taddCandidate(\"Candidate 1\");\r\n\taddCandidate(\"Candidate 2\");\r\n  addVoter(100);  // Null NID\r\n  addVoter(200);\r\n}\r\n\r\n// candidates are pre populated for the election\r\nfunction addCandidate(string _name) private {\r\ncandidatesCount++;\r\ncandidates[candidatesCount] = Candidate(candidatesCount, _name, 0);\r\n}\r\n\r\n// anyone can register for the election\r\nfunction addVoter(uint _nationalID) public {\r\nvotersCount++;\r\nvoters[msg.sender] = Voter(_nationalID,true,false,0,0);   // (NID, eligibility, hasVoted, BlindedVote, signedBlindedVote)\r\n}\r\n\r\nfunction vote(uint _candidateId) public {\r\n\r\n        // registered voter check\r\n        require(voters[msg.sender].eligibility == true);\r\n\r\n        // require that they haven't voted before\r\n        require(!voters[msg.sender].hasVoted);\r\n\r\n        // require a valid candidate\r\n        require(_candidateId > 0 && _candidateId <= candidatesCount);\r\n\r\n        // record that voter has voted\r\n        voters[msg.sender].hasVoted = true;\r\n\r\n        // update candidate vote Count\r\n        candidates[_candidateId].voteCount++;\r\n\r\n        //trigger voted event\r\n        emit votedEvent(_candidateId);\r\n    }\r\n}\r\n",
   "sourcePath": "L:/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/election.sol",
   "ast": {
     "absolutePath": "/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/election.sol",
     "exportedSymbols": {
       "Election": [
-        152
+        207
       ]
     },
-    "id": 153,
+    "id": 208,
     "nodeType": "SourceUnit",
     "nodes": [
       {
@@ -128,9 +172,9 @@
         "contractKind": "contract",
         "documentation": null,
         "fullyImplemented": true,
-        "id": 152,
+        "id": 207,
         "linearizedBaseContracts": [
-          152
+          207
         ],
         "name": "Election",
         "nodeType": "ContractDefinition",
@@ -220,17 +264,158 @@
             ],
             "name": "Candidate",
             "nodeType": "StructDefinition",
-            "scope": 152,
+            "scope": 207,
             "src": "71:65:1",
             "visibility": "public"
           },
           {
+            "canonicalName": "Election.Voter",
+            "id": 76,
+            "members": [
+              {
+                "constant": false,
+                "id": 67,
+                "name": "NID",
+                "nodeType": "VariableDeclaration",
+                "scope": 76,
+                "src": "173:8:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_uint256",
+                  "typeString": "uint256"
+                },
+                "typeName": {
+                  "id": 66,
+                  "name": "uint",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "173:4:1",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  }
+                },
+                "value": null,
+                "visibility": "internal"
+              },
+              {
+                "constant": false,
+                "id": 69,
+                "name": "eligibility",
+                "nodeType": "VariableDeclaration",
+                "scope": 76,
+                "src": "249:16:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_bool",
+                  "typeString": "bool"
+                },
+                "typeName": {
+                  "id": 68,
+                  "name": "bool",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "249:4:1",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bool",
+                    "typeString": "bool"
+                  }
+                },
+                "value": null,
+                "visibility": "internal"
+              },
+              {
+                "constant": false,
+                "id": 71,
+                "name": "hasVoted",
+                "nodeType": "VariableDeclaration",
+                "scope": 76,
+                "src": "330:13:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_bool",
+                  "typeString": "bool"
+                },
+                "typeName": {
+                  "id": 70,
+                  "name": "bool",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "330:4:1",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bool",
+                    "typeString": "bool"
+                  }
+                },
+                "value": null,
+                "visibility": "internal"
+              },
+              {
+                "constant": false,
+                "id": 73,
+                "name": "blindedVote",
+                "nodeType": "VariableDeclaration",
+                "scope": 76,
+                "src": "409:16:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_uint256",
+                  "typeString": "uint256"
+                },
+                "typeName": {
+                  "id": 72,
+                  "name": "uint",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "409:4:1",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  }
+                },
+                "value": null,
+                "visibility": "internal"
+              },
+              {
+                "constant": false,
+                "id": 75,
+                "name": "signedBlindedVote",
+                "nodeType": "VariableDeclaration",
+                "scope": 76,
+                "src": "468:22:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_uint256",
+                  "typeString": "uint256"
+                },
+                "typeName": {
+                  "id": 74,
+                  "name": "uint",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "468:4:1",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  }
+                },
+                "value": null,
+                "visibility": "internal"
+              }
+            ],
+            "name": "Voter",
+            "nodeType": "StructDefinition",
+            "scope": 207,
+            "src": "155:374:1",
+            "visibility": "public"
+          },
+          {
             "constant": false,
-            "id": 69,
+            "id": 80,
             "name": "candidates",
             "nodeType": "VariableDeclaration",
-            "scope": 152,
-            "src": "166:44:1",
+            "scope": 207,
+            "src": "557:44:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -238,30 +423,30 @@
               "typeString": "mapping(uint256 => struct Election.Candidate)"
             },
             "typeName": {
-              "id": 68,
+              "id": 79,
               "keyType": {
-                "id": 66,
+                "id": 77,
                 "name": "uint",
                 "nodeType": "ElementaryTypeName",
-                "src": "174:4:1",
+                "src": "565:4:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_uint256",
                   "typeString": "uint256"
                 }
               },
               "nodeType": "Mapping",
-              "src": "166:26:1",
+              "src": "557:26:1",
               "typeDescriptions": {
                 "typeIdentifier": "t_mapping$_t_uint256_$_t_struct$_Candidate_$65_storage_$",
                 "typeString": "mapping(uint256 => struct Election.Candidate)"
               },
               "valueType": {
                 "contractScope": null,
-                "id": 67,
+                "id": 78,
                 "name": "Candidate",
                 "nodeType": "UserDefinedTypeName",
                 "referencedDeclaration": 65,
-                "src": "182:9:1",
+                "src": "573:9:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_struct$_Candidate_$65_storage_ptr",
                   "typeString": "struct Election.Candidate"
@@ -273,43 +458,45 @@
           },
           {
             "constant": false,
-            "id": 73,
+            "id": 84,
             "name": "voters",
             "nodeType": "VariableDeclaration",
-            "scope": 152,
-            "src": "250:38:1",
+            "scope": 207,
+            "src": "641:39:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
-              "typeIdentifier": "t_mapping$_t_address_$_t_bool_$",
-              "typeString": "mapping(address => bool)"
+              "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+              "typeString": "mapping(address => struct Election.Voter)"
             },
             "typeName": {
-              "id": 72,
+              "id": 83,
               "keyType": {
-                "id": 70,
+                "id": 81,
                 "name": "address",
                 "nodeType": "ElementaryTypeName",
-                "src": "258:7:1",
+                "src": "649:7:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_address",
                   "typeString": "address"
                 }
               },
               "nodeType": "Mapping",
-              "src": "250:24:1",
+              "src": "641:25:1",
               "typeDescriptions": {
-                "typeIdentifier": "t_mapping$_t_address_$_t_bool_$",
-                "typeString": "mapping(address => bool)"
+                "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+                "typeString": "mapping(address => struct Election.Voter)"
               },
               "valueType": {
-                "id": 71,
-                "name": "bool",
-                "nodeType": "ElementaryTypeName",
-                "src": "269:4:1",
+                "contractScope": null,
+                "id": 82,
+                "name": "Voter",
+                "nodeType": "UserDefinedTypeName",
+                "referencedDeclaration": 76,
+                "src": "660:5:1",
                 "typeDescriptions": {
-                  "typeIdentifier": "t_bool",
-                  "typeString": "bool"
+                  "typeIdentifier": "t_struct$_Voter_$76_storage_ptr",
+                  "typeString": "struct Election.Voter"
                 }
               }
             },
@@ -319,21 +506,21 @@
           {
             "anonymous": false,
             "documentation": null,
-            "id": 77,
+            "id": 88,
             "name": "votedEvent",
             "nodeType": "EventDefinition",
             "parameters": {
-              "id": 76,
+              "id": 87,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 75,
+                  "id": 86,
                   "indexed": true,
                   "name": "_candidateId",
                   "nodeType": "VariableDeclaration",
-                  "scope": 77,
-                  "src": "353:25:1",
+                  "scope": 88,
+                  "src": "745:25:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -341,10 +528,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 74,
+                    "id": 85,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
-                    "src": "353:4:1",
+                    "src": "745:4:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -354,17 +541,17 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "348:35:1"
+              "src": "740:35:1"
             },
-            "src": "332:52:1"
+            "src": "724:52:1"
           },
           {
             "constant": false,
-            "id": 79,
+            "id": 90,
             "name": "candidatesCount",
             "nodeType": "VariableDeclaration",
-            "scope": 152,
-            "src": "413:27:1",
+            "scope": 207,
+            "src": "805:27:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -372,10 +559,36 @@
               "typeString": "uint256"
             },
             "typeName": {
-              "id": 78,
+              "id": 89,
               "name": "uint",
               "nodeType": "ElementaryTypeName",
-              "src": "413:4:1",
+              "src": "805:4:1",
+              "typeDescriptions": {
+                "typeIdentifier": "t_uint256",
+                "typeString": "uint256"
+              }
+            },
+            "value": null,
+            "visibility": "public"
+          },
+          {
+            "constant": false,
+            "id": 92,
+            "name": "votersCount",
+            "nodeType": "VariableDeclaration",
+            "scope": 207,
+            "src": "869:23:1",
+            "stateVariable": true,
+            "storageLocation": "default",
+            "typeDescriptions": {
+              "typeIdentifier": "t_uint256",
+              "typeString": "uint256"
+            },
+            "typeName": {
+              "id": 91,
+              "name": "uint",
+              "nodeType": "ElementaryTypeName",
+              "src": "869:4:1",
               "typeDescriptions": {
                 "typeIdentifier": "t_uint256",
                 "typeString": "uint256"
@@ -386,9 +599,9 @@
           },
           {
             "body": {
-              "id": 90,
+              "id": 111,
               "nodeType": "Block",
-              "src": "466:66:1",
+              "src": "949:115:1",
               "statements": [
                 {
                   "expression": {
@@ -397,14 +610,14 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "43616e6469646174652031",
-                        "id": 83,
+                        "id": 96,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
                         "kind": "string",
                         "lValueRequested": false,
                         "nodeType": "Literal",
-                        "src": "483:13:1",
+                        "src": "966:13:1",
                         "subdenomination": null,
                         "typeDescriptions": {
                           "typeIdentifier": "t_stringliteral_41f9dcbd43e9b33194759b5a51b1df9864cdc2b2138ff106f03091eb79861f0c",
@@ -420,18 +633,18 @@
                           "typeString": "literal_string \"Candidate 1\""
                         }
                       ],
-                      "id": 82,
+                      "id": 95,
                       "name": "addCandidate",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 110,
-                      "src": "470:12:1",
+                      "referencedDeclaration": 131,
+                      "src": "953:12:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_nonpayable$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (string memory)"
                       }
                     },
-                    "id": 84,
+                    "id": 97,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -439,15 +652,15 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "470:27:1",
+                    "src": "953:27:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 85,
+                  "id": 98,
                   "nodeType": "ExpressionStatement",
-                  "src": "470:27:1"
+                  "src": "953:27:1"
                 },
                 {
                   "expression": {
@@ -456,14 +669,14 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "43616e6469646174652032",
-                        "id": 87,
+                        "id": 100,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
                         "kind": "string",
                         "lValueRequested": false,
                         "nodeType": "Literal",
-                        "src": "514:13:1",
+                        "src": "997:13:1",
                         "subdenomination": null,
                         "typeDescriptions": {
                           "typeIdentifier": "t_stringliteral_f1f17440f69835dafba5c9fd0e4caa6c780807a80f8d1745ec7af1408d6cca4a",
@@ -479,18 +692,18 @@
                           "typeString": "literal_string \"Candidate 2\""
                         }
                       ],
-                      "id": 86,
+                      "id": 99,
                       "name": "addCandidate",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 110,
-                      "src": "501:12:1",
+                      "referencedDeclaration": 131,
+                      "src": "984:12:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_nonpayable$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (string memory)"
                       }
                     },
-                    "id": 88,
+                    "id": 101,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -498,20 +711,138 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "501:27:1",
+                    "src": "984:27:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 89,
+                  "id": 102,
                   "nodeType": "ExpressionStatement",
-                  "src": "501:27:1"
+                  "src": "984:27:1"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "arguments": [
+                      {
+                        "argumentTypes": null,
+                        "hexValue": "313030",
+                        "id": 104,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "kind": "number",
+                        "lValueRequested": false,
+                        "nodeType": "Literal",
+                        "src": "1025:3:1",
+                        "subdenomination": null,
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_rational_100_by_1",
+                          "typeString": "int_const 100"
+                        },
+                        "value": "100"
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_rational_100_by_1",
+                          "typeString": "int_const 100"
+                        }
+                      ],
+                      "id": 103,
+                      "name": "addVoter",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 153,
+                      "src": "1016:8:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_internal_nonpayable$_t_uint256_$returns$__$",
+                        "typeString": "function (uint256)"
+                      }
+                    },
+                    "id": 105,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "1016:13:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 106,
+                  "nodeType": "ExpressionStatement",
+                  "src": "1016:13:1"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "arguments": [
+                      {
+                        "argumentTypes": null,
+                        "hexValue": "323030",
+                        "id": 108,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "kind": "number",
+                        "lValueRequested": false,
+                        "nodeType": "Literal",
+                        "src": "1056:3:1",
+                        "subdenomination": null,
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_rational_200_by_1",
+                          "typeString": "int_const 200"
+                        },
+                        "value": "200"
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_rational_200_by_1",
+                          "typeString": "int_const 200"
+                        }
+                      ],
+                      "id": 107,
+                      "name": "addVoter",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 153,
+                      "src": "1047:8:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_internal_nonpayable$_t_uint256_$returns$__$",
+                        "typeString": "function (uint256)"
+                      }
+                    },
+                    "id": 109,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "1047:13:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 110,
+                  "nodeType": "ExpressionStatement",
+                  "src": "1047:13:1"
                 }
               ]
             },
             "documentation": null,
-            "id": 91,
+            "id": 112,
             "implemented": true,
             "isConstructor": true,
             "isDeclaredConst": false,
@@ -519,34 +850,34 @@
             "name": "",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 80,
+              "id": 93,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "456:2:1"
+              "src": "939:2:1"
             },
             "payable": false,
             "returnParameters": {
-              "id": 81,
+              "id": 94,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "466:0:1"
+              "src": "949:0:1"
             },
-            "scope": 152,
-            "src": "445:87:1",
+            "scope": 207,
+            "src": "928:136:1",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
           },
           {
             "body": {
-              "id": 109,
+              "id": 130,
               "nodeType": "Block",
-              "src": "580:93:1",
+              "src": "1162:93:1",
               "statements": [
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 97,
+                    "id": 118,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -554,15 +885,15 @@
                     "nodeType": "UnaryOperation",
                     "operator": "++",
                     "prefix": false,
-                    "src": "583:17:1",
+                    "src": "1165:17:1",
                     "subExpression": {
                       "argumentTypes": null,
-                      "id": 96,
+                      "id": 117,
                       "name": "candidatesCount",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 79,
-                      "src": "583:15:1",
+                      "referencedDeclaration": 90,
+                      "src": "1165:15:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
@@ -573,14 +904,14 @@
                       "typeString": "uint256"
                     }
                   },
-                  "id": 98,
+                  "id": 119,
                   "nodeType": "ExpressionStatement",
-                  "src": "583:17:1"
+                  "src": "1165:17:1"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 107,
+                    "id": 128,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -589,26 +920,26 @@
                       "argumentTypes": null,
                       "baseExpression": {
                         "argumentTypes": null,
-                        "id": 99,
+                        "id": 120,
                         "name": "candidates",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 69,
-                        "src": "603:10:1",
+                        "referencedDeclaration": 80,
+                        "src": "1185:10:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_uint256_$_t_struct$_Candidate_$65_storage_$",
                           "typeString": "mapping(uint256 => struct Election.Candidate storage ref)"
                         }
                       },
-                      "id": 101,
+                      "id": 122,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 100,
+                        "id": 121,
                         "name": "candidatesCount",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 79,
-                        "src": "614:15:1",
+                        "referencedDeclaration": 90,
+                        "src": "1196:15:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
@@ -619,7 +950,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "603:27:1",
+                      "src": "1185:27:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_struct$_Candidate_$65_storage",
                         "typeString": "struct Election.Candidate storage ref"
@@ -632,12 +963,12 @@
                       "arguments": [
                         {
                           "argumentTypes": null,
-                          "id": 103,
+                          "id": 124,
                           "name": "candidatesCount",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 79,
-                          "src": "643:15:1",
+                          "referencedDeclaration": 90,
+                          "src": "1225:15:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
@@ -645,12 +976,12 @@
                         },
                         {
                           "argumentTypes": null,
-                          "id": 104,
+                          "id": 125,
                           "name": "_name",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 93,
-                          "src": "660:5:1",
+                          "referencedDeclaration": 114,
+                          "src": "1242:5:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_string_memory_ptr",
                             "typeString": "string memory"
@@ -659,14 +990,14 @@
                         {
                           "argumentTypes": null,
                           "hexValue": "30",
-                          "id": 105,
+                          "id": 126,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
                           "kind": "number",
                           "lValueRequested": false,
                           "nodeType": "Literal",
-                          "src": "667:1:1",
+                          "src": "1249:1:1",
                           "subdenomination": null,
                           "typeDescriptions": {
                             "typeIdentifier": "t_rational_0_by_1",
@@ -690,18 +1021,18 @@
                             "typeString": "int_const 0"
                           }
                         ],
-                        "id": 102,
+                        "id": 123,
                         "name": "Candidate",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 65,
-                        "src": "633:9:1",
+                        "src": "1215:9:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_type$_t_struct$_Candidate_$65_storage_ptr_$",
                           "typeString": "type(struct Election.Candidate storage pointer)"
                         }
                       },
-                      "id": 106,
+                      "id": 127,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
@@ -709,26 +1040,26 @@
                       "lValueRequested": false,
                       "names": [],
                       "nodeType": "FunctionCall",
-                      "src": "633:36:1",
+                      "src": "1215:36:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_struct$_Candidate_$65_memory",
                         "typeString": "struct Election.Candidate memory"
                       }
                     },
-                    "src": "603:66:1",
+                    "src": "1185:66:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_struct$_Candidate_$65_storage",
                       "typeString": "struct Election.Candidate storage ref"
                     }
                   },
-                  "id": 108,
+                  "id": 129,
                   "nodeType": "ExpressionStatement",
-                  "src": "603:66:1"
+                  "src": "1185:66:1"
                 }
               ]
             },
             "documentation": null,
-            "id": 110,
+            "id": 131,
             "implemented": true,
             "isConstructor": false,
             "isDeclaredConst": false,
@@ -736,16 +1067,16 @@
             "name": "addCandidate",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 94,
+              "id": 115,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 93,
+                  "id": 114,
                   "name": "_name",
                   "nodeType": "VariableDeclaration",
-                  "scope": 110,
-                  "src": "558:12:1",
+                  "scope": 131,
+                  "src": "1140:12:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -753,10 +1084,10 @@
                     "typeString": "string"
                   },
                   "typeName": {
-                    "id": 92,
+                    "id": 113,
                     "name": "string",
                     "nodeType": "ElementaryTypeName",
-                    "src": "558:6:1",
+                    "src": "1140:6:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_string_storage_ptr",
                       "typeString": "string"
@@ -766,26 +1097,335 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "557:14:1"
+              "src": "1139:14:1"
             },
             "payable": false,
             "returnParameters": {
-              "id": 95,
+              "id": 116,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "580:0:1"
+              "src": "1162:0:1"
             },
-            "scope": 152,
-            "src": "536:137:1",
+            "scope": 207,
+            "src": "1118:137:1",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "private"
           },
           {
             "body": {
-              "id": 150,
+              "id": 152,
               "nodeType": "Block",
-              "src": "718:444:1",
+              "src": "1343:143:1",
+              "statements": [
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "id": 137,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "nodeType": "UnaryOperation",
+                    "operator": "++",
+                    "prefix": false,
+                    "src": "1346:13:1",
+                    "subExpression": {
+                      "argumentTypes": null,
+                      "id": 136,
+                      "name": "votersCount",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 92,
+                      "src": "1346:11:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "id": 138,
+                  "nodeType": "ExpressionStatement",
+                  "src": "1346:13:1"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "id": 150,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "argumentTypes": null,
+                      "baseExpression": {
+                        "argumentTypes": null,
+                        "id": 139,
+                        "name": "voters",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 84,
+                        "src": "1362:6:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+                          "typeString": "mapping(address => struct Election.Voter storage ref)"
+                        }
+                      },
+                      "id": 142,
+                      "indexExpression": {
+                        "argumentTypes": null,
+                        "expression": {
+                          "argumentTypes": null,
+                          "id": 140,
+                          "name": "msg",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 222,
+                          "src": "1369:3:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_magic_message",
+                            "typeString": "msg"
+                          }
+                        },
+                        "id": 141,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "memberName": "sender",
+                        "nodeType": "MemberAccess",
+                        "referencedDeclaration": null,
+                        "src": "1369:10:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      "isConstant": false,
+                      "isLValue": true,
+                      "isPure": false,
+                      "lValueRequested": true,
+                      "nodeType": "IndexAccess",
+                      "src": "1362:18:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_struct$_Voter_$76_storage",
+                        "typeString": "struct Election.Voter storage ref"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "argumentTypes": null,
+                      "arguments": [
+                        {
+                          "argumentTypes": null,
+                          "id": 144,
+                          "name": "_nationalID",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 133,
+                          "src": "1389:11:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        {
+                          "argumentTypes": null,
+                          "hexValue": "74727565",
+                          "id": 145,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "bool",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "1401:4:1",
+                          "subdenomination": null,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          },
+                          "value": "true"
+                        },
+                        {
+                          "argumentTypes": null,
+                          "hexValue": "66616c7365",
+                          "id": 146,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "bool",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "1406:5:1",
+                          "subdenomination": null,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          },
+                          "value": "false"
+                        },
+                        {
+                          "argumentTypes": null,
+                          "hexValue": "30",
+                          "id": 147,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "number",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "1412:1:1",
+                          "subdenomination": null,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_rational_0_by_1",
+                            "typeString": "int_const 0"
+                          },
+                          "value": "0"
+                        },
+                        {
+                          "argumentTypes": null,
+                          "hexValue": "30",
+                          "id": 148,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "number",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "1414:1:1",
+                          "subdenomination": null,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_rational_0_by_1",
+                            "typeString": "int_const 0"
+                          },
+                          "value": "0"
+                        }
+                      ],
+                      "expression": {
+                        "argumentTypes": [
+                          {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          },
+                          {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          },
+                          {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          },
+                          {
+                            "typeIdentifier": "t_rational_0_by_1",
+                            "typeString": "int_const 0"
+                          },
+                          {
+                            "typeIdentifier": "t_rational_0_by_1",
+                            "typeString": "int_const 0"
+                          }
+                        ],
+                        "id": 143,
+                        "name": "Voter",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 76,
+                        "src": "1383:5:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_type$_t_struct$_Voter_$76_storage_ptr_$",
+                          "typeString": "type(struct Election.Voter storage pointer)"
+                        }
+                      },
+                      "id": 149,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "kind": "structConstructorCall",
+                      "lValueRequested": false,
+                      "names": [],
+                      "nodeType": "FunctionCall",
+                      "src": "1383:33:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_struct$_Voter_$76_memory",
+                        "typeString": "struct Election.Voter memory"
+                      }
+                    },
+                    "src": "1362:54:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_struct$_Voter_$76_storage",
+                      "typeString": "struct Election.Voter storage ref"
+                    }
+                  },
+                  "id": 151,
+                  "nodeType": "ExpressionStatement",
+                  "src": "1362:54:1"
+                }
+              ]
+            },
+            "documentation": null,
+            "id": 153,
+            "implemented": true,
+            "isConstructor": false,
+            "isDeclaredConst": false,
+            "modifiers": [],
+            "name": "addVoter",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 134,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 133,
+                  "name": "_nationalID",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 153,
+                  "src": "1318:16:1",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 132,
+                    "name": "uint",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1318:4:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                }
+              ],
+              "src": "1317:18:1"
+            },
+            "payable": false,
+            "returnParameters": {
+              "id": 135,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "1343:0:1"
+            },
+            "scope": 207,
+            "src": "1300:186:1",
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          {
+            "body": {
+              "id": 205,
+              "nodeType": "Block",
+              "src": "1530:564:1",
               "statements": [
                 {
                   "expression": {
@@ -793,7 +1433,160 @@
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 120,
+                        "commonType": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        },
+                        "id": 165,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftExpression": {
+                          "argumentTypes": null,
+                          "expression": {
+                            "argumentTypes": null,
+                            "baseExpression": {
+                              "argumentTypes": null,
+                              "id": 159,
+                              "name": "voters",
+                              "nodeType": "Identifier",
+                              "overloadedDeclarations": [],
+                              "referencedDeclaration": 84,
+                              "src": "1586:6:1",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+                                "typeString": "mapping(address => struct Election.Voter storage ref)"
+                              }
+                            },
+                            "id": 162,
+                            "indexExpression": {
+                              "argumentTypes": null,
+                              "expression": {
+                                "argumentTypes": null,
+                                "id": 160,
+                                "name": "msg",
+                                "nodeType": "Identifier",
+                                "overloadedDeclarations": [],
+                                "referencedDeclaration": 222,
+                                "src": "1593:3:1",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_magic_message",
+                                  "typeString": "msg"
+                                }
+                              },
+                              "id": 161,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "memberName": "sender",
+                              "nodeType": "MemberAccess",
+                              "referencedDeclaration": null,
+                              "src": "1593:10:1",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_address",
+                                "typeString": "address"
+                              }
+                            },
+                            "isConstant": false,
+                            "isLValue": true,
+                            "isPure": false,
+                            "lValueRequested": false,
+                            "nodeType": "IndexAccess",
+                            "src": "1586:18:1",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_struct$_Voter_$76_storage",
+                              "typeString": "struct Election.Voter storage ref"
+                            }
+                          },
+                          "id": 163,
+                          "isConstant": false,
+                          "isLValue": true,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "memberName": "eligibility",
+                          "nodeType": "MemberAccess",
+                          "referencedDeclaration": 69,
+                          "src": "1586:30:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          }
+                        },
+                        "nodeType": "BinaryOperation",
+                        "operator": "==",
+                        "rightExpression": {
+                          "argumentTypes": null,
+                          "hexValue": "74727565",
+                          "id": 164,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "bool",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "1620:4:1",
+                          "subdenomination": null,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          },
+                          "value": "true"
+                        },
+                        "src": "1586:38:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      ],
+                      "id": 158,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        225,
+                        226
+                      ],
+                      "referencedDeclaration": 225,
+                      "src": "1578:7:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
+                        "typeString": "function (bool) pure"
+                      }
+                    },
+                    "id": 166,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "1578:47:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 167,
+                  "nodeType": "ExpressionStatement",
+                  "src": "1578:47:1"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "arguments": [
+                      {
+                        "argumentTypes": null,
+                        "id": 174,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -801,58 +1594,74 @@
                         "nodeType": "UnaryOperation",
                         "operator": "!",
                         "prefix": true,
-                        "src": "788:19:1",
+                        "src": "1697:28:1",
                         "subExpression": {
                           "argumentTypes": null,
-                          "baseExpression": {
+                          "expression": {
                             "argumentTypes": null,
-                            "id": 116,
-                            "name": "voters",
-                            "nodeType": "Identifier",
-                            "overloadedDeclarations": [],
-                            "referencedDeclaration": 73,
-                            "src": "789:6:1",
-                            "typeDescriptions": {
-                              "typeIdentifier": "t_mapping$_t_address_$_t_bool_$",
-                              "typeString": "mapping(address => bool)"
-                            }
-                          },
-                          "id": 119,
-                          "indexExpression": {
-                            "argumentTypes": null,
-                            "expression": {
+                            "baseExpression": {
                               "argumentTypes": null,
-                              "id": 117,
-                              "name": "msg",
+                              "id": 169,
+                              "name": "voters",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 167,
-                              "src": "796:3:1",
+                              "referencedDeclaration": 84,
+                              "src": "1698:6:1",
                               "typeDescriptions": {
-                                "typeIdentifier": "t_magic_message",
-                                "typeString": "msg"
+                                "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+                                "typeString": "mapping(address => struct Election.Voter storage ref)"
                               }
                             },
-                            "id": 118,
+                            "id": 172,
+                            "indexExpression": {
+                              "argumentTypes": null,
+                              "expression": {
+                                "argumentTypes": null,
+                                "id": 170,
+                                "name": "msg",
+                                "nodeType": "Identifier",
+                                "overloadedDeclarations": [],
+                                "referencedDeclaration": 222,
+                                "src": "1705:3:1",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_magic_message",
+                                  "typeString": "msg"
+                                }
+                              },
+                              "id": 171,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "memberName": "sender",
+                              "nodeType": "MemberAccess",
+                              "referencedDeclaration": null,
+                              "src": "1705:10:1",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_address",
+                                "typeString": "address"
+                              }
+                            },
                             "isConstant": false,
-                            "isLValue": false,
+                            "isLValue": true,
                             "isPure": false,
                             "lValueRequested": false,
-                            "memberName": "sender",
-                            "nodeType": "MemberAccess",
-                            "referencedDeclaration": null,
-                            "src": "796:10:1",
+                            "nodeType": "IndexAccess",
+                            "src": "1698:18:1",
                             "typeDescriptions": {
-                              "typeIdentifier": "t_address",
-                              "typeString": "address"
+                              "typeIdentifier": "t_struct$_Voter_$76_storage",
+                              "typeString": "struct Election.Voter storage ref"
                             }
                           },
+                          "id": 173,
                           "isConstant": false,
                           "isLValue": true,
                           "isPure": false,
                           "lValueRequested": false,
-                          "nodeType": "IndexAccess",
-                          "src": "789:18:1",
+                          "memberName": "hasVoted",
+                          "nodeType": "MemberAccess",
+                          "referencedDeclaration": 71,
+                          "src": "1698:27:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
@@ -871,21 +1680,21 @@
                           "typeString": "bool"
                         }
                       ],
-                      "id": 115,
+                      "id": 168,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        170,
-                        171
+                        225,
+                        226
                       ],
-                      "referencedDeclaration": 170,
-                      "src": "780:7:1",
+                      "referencedDeclaration": 225,
+                      "src": "1689:7:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
                         "typeString": "function (bool) pure"
                       }
                     },
-                    "id": 121,
+                    "id": 175,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -893,15 +1702,15 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "780:28:1",
+                    "src": "1689:37:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 122,
+                  "id": 176,
                   "nodeType": "ExpressionStatement",
-                  "src": "780:28:1"
+                  "src": "1689:37:1"
                 },
                 {
                   "expression": {
@@ -913,7 +1722,7 @@
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
                         },
-                        "id": 130,
+                        "id": 184,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -924,19 +1733,19 @@
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
                           },
-                          "id": 126,
+                          "id": 180,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftExpression": {
                             "argumentTypes": null,
-                            "id": 124,
+                            "id": 178,
                             "name": "_candidateId",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 112,
-                            "src": "867:12:1",
+                            "referencedDeclaration": 155,
+                            "src": "1785:12:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
@@ -947,14 +1756,14 @@
                           "rightExpression": {
                             "argumentTypes": null,
                             "hexValue": "30",
-                            "id": 125,
+                            "id": 179,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
                             "kind": "number",
                             "lValueRequested": false,
                             "nodeType": "Literal",
-                            "src": "882:1:1",
+                            "src": "1800:1:1",
                             "subdenomination": null,
                             "typeDescriptions": {
                               "typeIdentifier": "t_rational_0_by_1",
@@ -962,7 +1771,7 @@
                             },
                             "value": "0"
                           },
-                          "src": "867:16:1",
+                          "src": "1785:16:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
@@ -976,19 +1785,19 @@
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
                           },
-                          "id": 129,
+                          "id": 183,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftExpression": {
                             "argumentTypes": null,
-                            "id": 127,
+                            "id": 181,
                             "name": "_candidateId",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 112,
-                            "src": "887:12:1",
+                            "referencedDeclaration": 155,
+                            "src": "1805:12:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
@@ -998,24 +1807,24 @@
                           "operator": "<=",
                           "rightExpression": {
                             "argumentTypes": null,
-                            "id": 128,
+                            "id": 182,
                             "name": "candidatesCount",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 79,
-                            "src": "903:15:1",
+                            "referencedDeclaration": 90,
+                            "src": "1821:15:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
                             }
                           },
-                          "src": "887:31:1",
+                          "src": "1805:31:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
                           }
                         },
-                        "src": "867:51:1",
+                        "src": "1785:51:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
@@ -1029,21 +1838,21 @@
                           "typeString": "bool"
                         }
                       ],
-                      "id": 123,
+                      "id": 177,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        170,
-                        171
+                        225,
+                        226
                       ],
-                      "referencedDeclaration": 170,
-                      "src": "859:7:1",
+                      "referencedDeclaration": 225,
+                      "src": "1777:7:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
                         "typeString": "function (bool) pure"
                       }
                     },
-                    "id": 131,
+                    "id": 185,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -1051,75 +1860,91 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "859:60:1",
+                    "src": "1777:60:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 132,
+                  "id": 186,
                   "nodeType": "ExpressionStatement",
-                  "src": "859:60:1"
+                  "src": "1777:60:1"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 138,
+                    "id": 193,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "baseExpression": {
+                      "expression": {
                         "argumentTypes": null,
-                        "id": 133,
-                        "name": "voters",
-                        "nodeType": "Identifier",
-                        "overloadedDeclarations": [],
-                        "referencedDeclaration": 73,
-                        "src": "972:6:1",
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_mapping$_t_address_$_t_bool_$",
-                          "typeString": "mapping(address => bool)"
-                        }
-                      },
-                      "id": 136,
-                      "indexExpression": {
-                        "argumentTypes": null,
-                        "expression": {
+                        "baseExpression": {
                           "argumentTypes": null,
-                          "id": 134,
-                          "name": "msg",
+                          "id": 187,
+                          "name": "voters",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 167,
-                          "src": "979:3:1",
+                          "referencedDeclaration": 84,
+                          "src": "1890:6:1",
                           "typeDescriptions": {
-                            "typeIdentifier": "t_magic_message",
-                            "typeString": "msg"
+                            "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+                            "typeString": "mapping(address => struct Election.Voter storage ref)"
                           }
                         },
-                        "id": 135,
+                        "id": 190,
+                        "indexExpression": {
+                          "argumentTypes": null,
+                          "expression": {
+                            "argumentTypes": null,
+                            "id": 188,
+                            "name": "msg",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 222,
+                            "src": "1897:3:1",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_magic_message",
+                              "typeString": "msg"
+                            }
+                          },
+                          "id": 189,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "memberName": "sender",
+                          "nodeType": "MemberAccess",
+                          "referencedDeclaration": null,
+                          "src": "1897:10:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          }
+                        },
                         "isConstant": false,
-                        "isLValue": false,
+                        "isLValue": true,
                         "isPure": false,
                         "lValueRequested": false,
-                        "memberName": "sender",
-                        "nodeType": "MemberAccess",
-                        "referencedDeclaration": null,
-                        "src": "979:10:1",
+                        "nodeType": "IndexAccess",
+                        "src": "1890:18:1",
                         "typeDescriptions": {
-                          "typeIdentifier": "t_address",
-                          "typeString": "address"
+                          "typeIdentifier": "t_struct$_Voter_$76_storage",
+                          "typeString": "struct Election.Voter storage ref"
                         }
                       },
+                      "id": 191,
                       "isConstant": false,
                       "isLValue": true,
                       "isPure": false,
                       "lValueRequested": true,
-                      "nodeType": "IndexAccess",
-                      "src": "972:18:1",
+                      "memberName": "hasVoted",
+                      "nodeType": "MemberAccess",
+                      "referencedDeclaration": 71,
+                      "src": "1890:27:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
                         "typeString": "bool"
@@ -1130,14 +1955,14 @@
                     "rightHandSide": {
                       "argumentTypes": null,
                       "hexValue": "74727565",
-                      "id": 137,
+                      "id": 192,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "kind": "bool",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "993:4:1",
+                      "src": "1920:4:1",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
@@ -1145,20 +1970,20 @@
                       },
                       "value": "true"
                     },
-                    "src": "972:25:1",
+                    "src": "1890:34:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
-                  "id": 139,
+                  "id": 194,
                   "nodeType": "ExpressionStatement",
-                  "src": "972:25:1"
+                  "src": "1890:34:1"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 144,
+                    "id": 199,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -1166,33 +1991,33 @@
                     "nodeType": "UnaryOperation",
                     "operator": "++",
                     "prefix": false,
-                    "src": "1050:36:1",
+                    "src": "1977:36:1",
                     "subExpression": {
                       "argumentTypes": null,
                       "expression": {
                         "argumentTypes": null,
                         "baseExpression": {
                           "argumentTypes": null,
-                          "id": 140,
+                          "id": 195,
                           "name": "candidates",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 69,
-                          "src": "1050:10:1",
+                          "referencedDeclaration": 80,
+                          "src": "1977:10:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_uint256_$_t_struct$_Candidate_$65_storage_$",
                             "typeString": "mapping(uint256 => struct Election.Candidate storage ref)"
                           }
                         },
-                        "id": 142,
+                        "id": 197,
                         "indexExpression": {
                           "argumentTypes": null,
-                          "id": 141,
+                          "id": 196,
                           "name": "_candidateId",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 112,
-                          "src": "1061:12:1",
+                          "referencedDeclaration": 155,
+                          "src": "1988:12:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
@@ -1203,13 +2028,13 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "1050:24:1",
+                        "src": "1977:24:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_struct$_Candidate_$65_storage",
                           "typeString": "struct Election.Candidate storage ref"
                         }
                       },
-                      "id": 143,
+                      "id": 198,
                       "isConstant": false,
                       "isLValue": true,
                       "isPure": false,
@@ -1217,7 +2042,7 @@
                       "memberName": "voteCount",
                       "nodeType": "MemberAccess",
                       "referencedDeclaration": 64,
-                      "src": "1050:34:1",
+                      "src": "1977:34:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
@@ -1228,22 +2053,22 @@
                       "typeString": "uint256"
                     }
                   },
-                  "id": 145,
+                  "id": 200,
                   "nodeType": "ExpressionStatement",
-                  "src": "1050:36:1"
+                  "src": "1977:36:1"
                 },
                 {
-                  "expression": {
+                  "eventCall": {
                     "argumentTypes": null,
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 147,
+                        "id": 202,
                         "name": "_candidateId",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 112,
-                        "src": "1141:12:1",
+                        "referencedDeclaration": 155,
+                        "src": "2073:12:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
@@ -1257,18 +2082,18 @@
                           "typeString": "uint256"
                         }
                       ],
-                      "id": 146,
+                      "id": 201,
                       "name": "votedEvent",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 77,
-                      "src": "1130:10:1",
+                      "referencedDeclaration": 88,
+                      "src": "2062:10:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_event_nonpayable$_t_uint256_$returns$__$",
                         "typeString": "function (uint256)"
                       }
                     },
-                    "id": 148,
+                    "id": 203,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -1276,20 +2101,20 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1130:24:1",
+                    "src": "2062:24:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 149,
-                  "nodeType": "ExpressionStatement",
-                  "src": "1130:24:1"
+                  "id": 204,
+                  "nodeType": "EmitStatement",
+                  "src": "2057:29:1"
                 }
               ]
             },
             "documentation": null,
-            "id": 151,
+            "id": 206,
             "implemented": true,
             "isConstructor": false,
             "isDeclaredConst": false,
@@ -1297,16 +2122,16 @@
             "name": "vote",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 113,
+              "id": 156,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 112,
+                  "id": 155,
                   "name": "_candidateId",
                   "nodeType": "VariableDeclaration",
-                  "scope": 151,
-                  "src": "692:17:1",
+                  "scope": 206,
+                  "src": "1504:17:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1314,10 +2139,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 111,
+                    "id": 154,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
-                    "src": "692:4:1",
+                    "src": "1504:4:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -1327,36 +2152,36 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "691:19:1"
+              "src": "1503:19:1"
             },
             "payable": false,
             "returnParameters": {
-              "id": 114,
+              "id": 157,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "718:0:1"
+              "src": "1530:0:1"
             },
-            "scope": 152,
-            "src": "678:484:1",
+            "scope": 207,
+            "src": "1490:604:1",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
           }
         ],
-        "scope": 153,
-        "src": "27:1138:1"
+        "scope": 208,
+        "src": "27:2070:1"
       }
     ],
-    "src": "0:1167:1"
+    "src": "0:2099:1"
   },
   "legacyAST": {
     "absolutePath": "/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/election.sol",
     "exportedSymbols": {
       "Election": [
-        152
+        207
       ]
     },
-    "id": 153,
+    "id": 208,
     "nodeType": "SourceUnit",
     "nodes": [
       {
@@ -1376,9 +2201,9 @@
         "contractKind": "contract",
         "documentation": null,
         "fullyImplemented": true,
-        "id": 152,
+        "id": 207,
         "linearizedBaseContracts": [
-          152
+          207
         ],
         "name": "Election",
         "nodeType": "ContractDefinition",
@@ -1468,17 +2293,158 @@
             ],
             "name": "Candidate",
             "nodeType": "StructDefinition",
-            "scope": 152,
+            "scope": 207,
             "src": "71:65:1",
             "visibility": "public"
           },
           {
+            "canonicalName": "Election.Voter",
+            "id": 76,
+            "members": [
+              {
+                "constant": false,
+                "id": 67,
+                "name": "NID",
+                "nodeType": "VariableDeclaration",
+                "scope": 76,
+                "src": "173:8:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_uint256",
+                  "typeString": "uint256"
+                },
+                "typeName": {
+                  "id": 66,
+                  "name": "uint",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "173:4:1",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  }
+                },
+                "value": null,
+                "visibility": "internal"
+              },
+              {
+                "constant": false,
+                "id": 69,
+                "name": "eligibility",
+                "nodeType": "VariableDeclaration",
+                "scope": 76,
+                "src": "249:16:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_bool",
+                  "typeString": "bool"
+                },
+                "typeName": {
+                  "id": 68,
+                  "name": "bool",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "249:4:1",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bool",
+                    "typeString": "bool"
+                  }
+                },
+                "value": null,
+                "visibility": "internal"
+              },
+              {
+                "constant": false,
+                "id": 71,
+                "name": "hasVoted",
+                "nodeType": "VariableDeclaration",
+                "scope": 76,
+                "src": "330:13:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_bool",
+                  "typeString": "bool"
+                },
+                "typeName": {
+                  "id": 70,
+                  "name": "bool",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "330:4:1",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bool",
+                    "typeString": "bool"
+                  }
+                },
+                "value": null,
+                "visibility": "internal"
+              },
+              {
+                "constant": false,
+                "id": 73,
+                "name": "blindedVote",
+                "nodeType": "VariableDeclaration",
+                "scope": 76,
+                "src": "409:16:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_uint256",
+                  "typeString": "uint256"
+                },
+                "typeName": {
+                  "id": 72,
+                  "name": "uint",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "409:4:1",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  }
+                },
+                "value": null,
+                "visibility": "internal"
+              },
+              {
+                "constant": false,
+                "id": 75,
+                "name": "signedBlindedVote",
+                "nodeType": "VariableDeclaration",
+                "scope": 76,
+                "src": "468:22:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_uint256",
+                  "typeString": "uint256"
+                },
+                "typeName": {
+                  "id": 74,
+                  "name": "uint",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "468:4:1",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  }
+                },
+                "value": null,
+                "visibility": "internal"
+              }
+            ],
+            "name": "Voter",
+            "nodeType": "StructDefinition",
+            "scope": 207,
+            "src": "155:374:1",
+            "visibility": "public"
+          },
+          {
             "constant": false,
-            "id": 69,
+            "id": 80,
             "name": "candidates",
             "nodeType": "VariableDeclaration",
-            "scope": 152,
-            "src": "166:44:1",
+            "scope": 207,
+            "src": "557:44:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -1486,30 +2452,30 @@
               "typeString": "mapping(uint256 => struct Election.Candidate)"
             },
             "typeName": {
-              "id": 68,
+              "id": 79,
               "keyType": {
-                "id": 66,
+                "id": 77,
                 "name": "uint",
                 "nodeType": "ElementaryTypeName",
-                "src": "174:4:1",
+                "src": "565:4:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_uint256",
                   "typeString": "uint256"
                 }
               },
               "nodeType": "Mapping",
-              "src": "166:26:1",
+              "src": "557:26:1",
               "typeDescriptions": {
                 "typeIdentifier": "t_mapping$_t_uint256_$_t_struct$_Candidate_$65_storage_$",
                 "typeString": "mapping(uint256 => struct Election.Candidate)"
               },
               "valueType": {
                 "contractScope": null,
-                "id": 67,
+                "id": 78,
                 "name": "Candidate",
                 "nodeType": "UserDefinedTypeName",
                 "referencedDeclaration": 65,
-                "src": "182:9:1",
+                "src": "573:9:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_struct$_Candidate_$65_storage_ptr",
                   "typeString": "struct Election.Candidate"
@@ -1521,43 +2487,45 @@
           },
           {
             "constant": false,
-            "id": 73,
+            "id": 84,
             "name": "voters",
             "nodeType": "VariableDeclaration",
-            "scope": 152,
-            "src": "250:38:1",
+            "scope": 207,
+            "src": "641:39:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
-              "typeIdentifier": "t_mapping$_t_address_$_t_bool_$",
-              "typeString": "mapping(address => bool)"
+              "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+              "typeString": "mapping(address => struct Election.Voter)"
             },
             "typeName": {
-              "id": 72,
+              "id": 83,
               "keyType": {
-                "id": 70,
+                "id": 81,
                 "name": "address",
                 "nodeType": "ElementaryTypeName",
-                "src": "258:7:1",
+                "src": "649:7:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_address",
                   "typeString": "address"
                 }
               },
               "nodeType": "Mapping",
-              "src": "250:24:1",
+              "src": "641:25:1",
               "typeDescriptions": {
-                "typeIdentifier": "t_mapping$_t_address_$_t_bool_$",
-                "typeString": "mapping(address => bool)"
+                "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+                "typeString": "mapping(address => struct Election.Voter)"
               },
               "valueType": {
-                "id": 71,
-                "name": "bool",
-                "nodeType": "ElementaryTypeName",
-                "src": "269:4:1",
+                "contractScope": null,
+                "id": 82,
+                "name": "Voter",
+                "nodeType": "UserDefinedTypeName",
+                "referencedDeclaration": 76,
+                "src": "660:5:1",
                 "typeDescriptions": {
-                  "typeIdentifier": "t_bool",
-                  "typeString": "bool"
+                  "typeIdentifier": "t_struct$_Voter_$76_storage_ptr",
+                  "typeString": "struct Election.Voter"
                 }
               }
             },
@@ -1567,21 +2535,21 @@
           {
             "anonymous": false,
             "documentation": null,
-            "id": 77,
+            "id": 88,
             "name": "votedEvent",
             "nodeType": "EventDefinition",
             "parameters": {
-              "id": 76,
+              "id": 87,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 75,
+                  "id": 86,
                   "indexed": true,
                   "name": "_candidateId",
                   "nodeType": "VariableDeclaration",
-                  "scope": 77,
-                  "src": "353:25:1",
+                  "scope": 88,
+                  "src": "745:25:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1589,10 +2557,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 74,
+                    "id": 85,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
-                    "src": "353:4:1",
+                    "src": "745:4:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -1602,17 +2570,17 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "348:35:1"
+              "src": "740:35:1"
             },
-            "src": "332:52:1"
+            "src": "724:52:1"
           },
           {
             "constant": false,
-            "id": 79,
+            "id": 90,
             "name": "candidatesCount",
             "nodeType": "VariableDeclaration",
-            "scope": 152,
-            "src": "413:27:1",
+            "scope": 207,
+            "src": "805:27:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -1620,10 +2588,36 @@
               "typeString": "uint256"
             },
             "typeName": {
-              "id": 78,
+              "id": 89,
               "name": "uint",
               "nodeType": "ElementaryTypeName",
-              "src": "413:4:1",
+              "src": "805:4:1",
+              "typeDescriptions": {
+                "typeIdentifier": "t_uint256",
+                "typeString": "uint256"
+              }
+            },
+            "value": null,
+            "visibility": "public"
+          },
+          {
+            "constant": false,
+            "id": 92,
+            "name": "votersCount",
+            "nodeType": "VariableDeclaration",
+            "scope": 207,
+            "src": "869:23:1",
+            "stateVariable": true,
+            "storageLocation": "default",
+            "typeDescriptions": {
+              "typeIdentifier": "t_uint256",
+              "typeString": "uint256"
+            },
+            "typeName": {
+              "id": 91,
+              "name": "uint",
+              "nodeType": "ElementaryTypeName",
+              "src": "869:4:1",
               "typeDescriptions": {
                 "typeIdentifier": "t_uint256",
                 "typeString": "uint256"
@@ -1634,9 +2628,9 @@
           },
           {
             "body": {
-              "id": 90,
+              "id": 111,
               "nodeType": "Block",
-              "src": "466:66:1",
+              "src": "949:115:1",
               "statements": [
                 {
                   "expression": {
@@ -1645,14 +2639,14 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "43616e6469646174652031",
-                        "id": 83,
+                        "id": 96,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
                         "kind": "string",
                         "lValueRequested": false,
                         "nodeType": "Literal",
-                        "src": "483:13:1",
+                        "src": "966:13:1",
                         "subdenomination": null,
                         "typeDescriptions": {
                           "typeIdentifier": "t_stringliteral_41f9dcbd43e9b33194759b5a51b1df9864cdc2b2138ff106f03091eb79861f0c",
@@ -1668,18 +2662,18 @@
                           "typeString": "literal_string \"Candidate 1\""
                         }
                       ],
-                      "id": 82,
+                      "id": 95,
                       "name": "addCandidate",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 110,
-                      "src": "470:12:1",
+                      "referencedDeclaration": 131,
+                      "src": "953:12:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_nonpayable$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (string memory)"
                       }
                     },
-                    "id": 84,
+                    "id": 97,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -1687,15 +2681,15 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "470:27:1",
+                    "src": "953:27:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 85,
+                  "id": 98,
                   "nodeType": "ExpressionStatement",
-                  "src": "470:27:1"
+                  "src": "953:27:1"
                 },
                 {
                   "expression": {
@@ -1704,14 +2698,14 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "43616e6469646174652032",
-                        "id": 87,
+                        "id": 100,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
                         "kind": "string",
                         "lValueRequested": false,
                         "nodeType": "Literal",
-                        "src": "514:13:1",
+                        "src": "997:13:1",
                         "subdenomination": null,
                         "typeDescriptions": {
                           "typeIdentifier": "t_stringliteral_f1f17440f69835dafba5c9fd0e4caa6c780807a80f8d1745ec7af1408d6cca4a",
@@ -1727,18 +2721,18 @@
                           "typeString": "literal_string \"Candidate 2\""
                         }
                       ],
-                      "id": 86,
+                      "id": 99,
                       "name": "addCandidate",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 110,
-                      "src": "501:12:1",
+                      "referencedDeclaration": 131,
+                      "src": "984:12:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_nonpayable$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (string memory)"
                       }
                     },
-                    "id": 88,
+                    "id": 101,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -1746,20 +2740,138 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "501:27:1",
+                    "src": "984:27:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 89,
+                  "id": 102,
                   "nodeType": "ExpressionStatement",
-                  "src": "501:27:1"
+                  "src": "984:27:1"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "arguments": [
+                      {
+                        "argumentTypes": null,
+                        "hexValue": "313030",
+                        "id": 104,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "kind": "number",
+                        "lValueRequested": false,
+                        "nodeType": "Literal",
+                        "src": "1025:3:1",
+                        "subdenomination": null,
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_rational_100_by_1",
+                          "typeString": "int_const 100"
+                        },
+                        "value": "100"
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_rational_100_by_1",
+                          "typeString": "int_const 100"
+                        }
+                      ],
+                      "id": 103,
+                      "name": "addVoter",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 153,
+                      "src": "1016:8:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_internal_nonpayable$_t_uint256_$returns$__$",
+                        "typeString": "function (uint256)"
+                      }
+                    },
+                    "id": 105,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "1016:13:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 106,
+                  "nodeType": "ExpressionStatement",
+                  "src": "1016:13:1"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "arguments": [
+                      {
+                        "argumentTypes": null,
+                        "hexValue": "323030",
+                        "id": 108,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "kind": "number",
+                        "lValueRequested": false,
+                        "nodeType": "Literal",
+                        "src": "1056:3:1",
+                        "subdenomination": null,
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_rational_200_by_1",
+                          "typeString": "int_const 200"
+                        },
+                        "value": "200"
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_rational_200_by_1",
+                          "typeString": "int_const 200"
+                        }
+                      ],
+                      "id": 107,
+                      "name": "addVoter",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 153,
+                      "src": "1047:8:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_internal_nonpayable$_t_uint256_$returns$__$",
+                        "typeString": "function (uint256)"
+                      }
+                    },
+                    "id": 109,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "1047:13:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 110,
+                  "nodeType": "ExpressionStatement",
+                  "src": "1047:13:1"
                 }
               ]
             },
             "documentation": null,
-            "id": 91,
+            "id": 112,
             "implemented": true,
             "isConstructor": true,
             "isDeclaredConst": false,
@@ -1767,34 +2879,34 @@
             "name": "",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 80,
+              "id": 93,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "456:2:1"
+              "src": "939:2:1"
             },
             "payable": false,
             "returnParameters": {
-              "id": 81,
+              "id": 94,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "466:0:1"
+              "src": "949:0:1"
             },
-            "scope": 152,
-            "src": "445:87:1",
+            "scope": 207,
+            "src": "928:136:1",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
           },
           {
             "body": {
-              "id": 109,
+              "id": 130,
               "nodeType": "Block",
-              "src": "580:93:1",
+              "src": "1162:93:1",
               "statements": [
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 97,
+                    "id": 118,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -1802,15 +2914,15 @@
                     "nodeType": "UnaryOperation",
                     "operator": "++",
                     "prefix": false,
-                    "src": "583:17:1",
+                    "src": "1165:17:1",
                     "subExpression": {
                       "argumentTypes": null,
-                      "id": 96,
+                      "id": 117,
                       "name": "candidatesCount",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 79,
-                      "src": "583:15:1",
+                      "referencedDeclaration": 90,
+                      "src": "1165:15:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
@@ -1821,14 +2933,14 @@
                       "typeString": "uint256"
                     }
                   },
-                  "id": 98,
+                  "id": 119,
                   "nodeType": "ExpressionStatement",
-                  "src": "583:17:1"
+                  "src": "1165:17:1"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 107,
+                    "id": 128,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -1837,26 +2949,26 @@
                       "argumentTypes": null,
                       "baseExpression": {
                         "argumentTypes": null,
-                        "id": 99,
+                        "id": 120,
                         "name": "candidates",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 69,
-                        "src": "603:10:1",
+                        "referencedDeclaration": 80,
+                        "src": "1185:10:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_uint256_$_t_struct$_Candidate_$65_storage_$",
                           "typeString": "mapping(uint256 => struct Election.Candidate storage ref)"
                         }
                       },
-                      "id": 101,
+                      "id": 122,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 100,
+                        "id": 121,
                         "name": "candidatesCount",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 79,
-                        "src": "614:15:1",
+                        "referencedDeclaration": 90,
+                        "src": "1196:15:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
@@ -1867,7 +2979,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "603:27:1",
+                      "src": "1185:27:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_struct$_Candidate_$65_storage",
                         "typeString": "struct Election.Candidate storage ref"
@@ -1880,12 +2992,12 @@
                       "arguments": [
                         {
                           "argumentTypes": null,
-                          "id": 103,
+                          "id": 124,
                           "name": "candidatesCount",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 79,
-                          "src": "643:15:1",
+                          "referencedDeclaration": 90,
+                          "src": "1225:15:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
@@ -1893,12 +3005,12 @@
                         },
                         {
                           "argumentTypes": null,
-                          "id": 104,
+                          "id": 125,
                           "name": "_name",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 93,
-                          "src": "660:5:1",
+                          "referencedDeclaration": 114,
+                          "src": "1242:5:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_string_memory_ptr",
                             "typeString": "string memory"
@@ -1907,14 +3019,14 @@
                         {
                           "argumentTypes": null,
                           "hexValue": "30",
-                          "id": 105,
+                          "id": 126,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
                           "kind": "number",
                           "lValueRequested": false,
                           "nodeType": "Literal",
-                          "src": "667:1:1",
+                          "src": "1249:1:1",
                           "subdenomination": null,
                           "typeDescriptions": {
                             "typeIdentifier": "t_rational_0_by_1",
@@ -1938,18 +3050,18 @@
                             "typeString": "int_const 0"
                           }
                         ],
-                        "id": 102,
+                        "id": 123,
                         "name": "Candidate",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 65,
-                        "src": "633:9:1",
+                        "src": "1215:9:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_type$_t_struct$_Candidate_$65_storage_ptr_$",
                           "typeString": "type(struct Election.Candidate storage pointer)"
                         }
                       },
-                      "id": 106,
+                      "id": 127,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
@@ -1957,26 +3069,26 @@
                       "lValueRequested": false,
                       "names": [],
                       "nodeType": "FunctionCall",
-                      "src": "633:36:1",
+                      "src": "1215:36:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_struct$_Candidate_$65_memory",
                         "typeString": "struct Election.Candidate memory"
                       }
                     },
-                    "src": "603:66:1",
+                    "src": "1185:66:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_struct$_Candidate_$65_storage",
                       "typeString": "struct Election.Candidate storage ref"
                     }
                   },
-                  "id": 108,
+                  "id": 129,
                   "nodeType": "ExpressionStatement",
-                  "src": "603:66:1"
+                  "src": "1185:66:1"
                 }
               ]
             },
             "documentation": null,
-            "id": 110,
+            "id": 131,
             "implemented": true,
             "isConstructor": false,
             "isDeclaredConst": false,
@@ -1984,16 +3096,16 @@
             "name": "addCandidate",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 94,
+              "id": 115,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 93,
+                  "id": 114,
                   "name": "_name",
                   "nodeType": "VariableDeclaration",
-                  "scope": 110,
-                  "src": "558:12:1",
+                  "scope": 131,
+                  "src": "1140:12:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2001,10 +3113,10 @@
                     "typeString": "string"
                   },
                   "typeName": {
-                    "id": 92,
+                    "id": 113,
                     "name": "string",
                     "nodeType": "ElementaryTypeName",
-                    "src": "558:6:1",
+                    "src": "1140:6:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_string_storage_ptr",
                       "typeString": "string"
@@ -2014,26 +3126,335 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "557:14:1"
+              "src": "1139:14:1"
             },
             "payable": false,
             "returnParameters": {
-              "id": 95,
+              "id": 116,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "580:0:1"
+              "src": "1162:0:1"
             },
-            "scope": 152,
-            "src": "536:137:1",
+            "scope": 207,
+            "src": "1118:137:1",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "private"
           },
           {
             "body": {
-              "id": 150,
+              "id": 152,
               "nodeType": "Block",
-              "src": "718:444:1",
+              "src": "1343:143:1",
+              "statements": [
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "id": 137,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "nodeType": "UnaryOperation",
+                    "operator": "++",
+                    "prefix": false,
+                    "src": "1346:13:1",
+                    "subExpression": {
+                      "argumentTypes": null,
+                      "id": 136,
+                      "name": "votersCount",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 92,
+                      "src": "1346:11:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "id": 138,
+                  "nodeType": "ExpressionStatement",
+                  "src": "1346:13:1"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "id": 150,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "argumentTypes": null,
+                      "baseExpression": {
+                        "argumentTypes": null,
+                        "id": 139,
+                        "name": "voters",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 84,
+                        "src": "1362:6:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+                          "typeString": "mapping(address => struct Election.Voter storage ref)"
+                        }
+                      },
+                      "id": 142,
+                      "indexExpression": {
+                        "argumentTypes": null,
+                        "expression": {
+                          "argumentTypes": null,
+                          "id": 140,
+                          "name": "msg",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 222,
+                          "src": "1369:3:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_magic_message",
+                            "typeString": "msg"
+                          }
+                        },
+                        "id": 141,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "memberName": "sender",
+                        "nodeType": "MemberAccess",
+                        "referencedDeclaration": null,
+                        "src": "1369:10:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      "isConstant": false,
+                      "isLValue": true,
+                      "isPure": false,
+                      "lValueRequested": true,
+                      "nodeType": "IndexAccess",
+                      "src": "1362:18:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_struct$_Voter_$76_storage",
+                        "typeString": "struct Election.Voter storage ref"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "argumentTypes": null,
+                      "arguments": [
+                        {
+                          "argumentTypes": null,
+                          "id": 144,
+                          "name": "_nationalID",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 133,
+                          "src": "1389:11:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        {
+                          "argumentTypes": null,
+                          "hexValue": "74727565",
+                          "id": 145,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "bool",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "1401:4:1",
+                          "subdenomination": null,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          },
+                          "value": "true"
+                        },
+                        {
+                          "argumentTypes": null,
+                          "hexValue": "66616c7365",
+                          "id": 146,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "bool",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "1406:5:1",
+                          "subdenomination": null,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          },
+                          "value": "false"
+                        },
+                        {
+                          "argumentTypes": null,
+                          "hexValue": "30",
+                          "id": 147,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "number",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "1412:1:1",
+                          "subdenomination": null,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_rational_0_by_1",
+                            "typeString": "int_const 0"
+                          },
+                          "value": "0"
+                        },
+                        {
+                          "argumentTypes": null,
+                          "hexValue": "30",
+                          "id": 148,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "number",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "1414:1:1",
+                          "subdenomination": null,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_rational_0_by_1",
+                            "typeString": "int_const 0"
+                          },
+                          "value": "0"
+                        }
+                      ],
+                      "expression": {
+                        "argumentTypes": [
+                          {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          },
+                          {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          },
+                          {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          },
+                          {
+                            "typeIdentifier": "t_rational_0_by_1",
+                            "typeString": "int_const 0"
+                          },
+                          {
+                            "typeIdentifier": "t_rational_0_by_1",
+                            "typeString": "int_const 0"
+                          }
+                        ],
+                        "id": 143,
+                        "name": "Voter",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 76,
+                        "src": "1383:5:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_type$_t_struct$_Voter_$76_storage_ptr_$",
+                          "typeString": "type(struct Election.Voter storage pointer)"
+                        }
+                      },
+                      "id": 149,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "kind": "structConstructorCall",
+                      "lValueRequested": false,
+                      "names": [],
+                      "nodeType": "FunctionCall",
+                      "src": "1383:33:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_struct$_Voter_$76_memory",
+                        "typeString": "struct Election.Voter memory"
+                      }
+                    },
+                    "src": "1362:54:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_struct$_Voter_$76_storage",
+                      "typeString": "struct Election.Voter storage ref"
+                    }
+                  },
+                  "id": 151,
+                  "nodeType": "ExpressionStatement",
+                  "src": "1362:54:1"
+                }
+              ]
+            },
+            "documentation": null,
+            "id": 153,
+            "implemented": true,
+            "isConstructor": false,
+            "isDeclaredConst": false,
+            "modifiers": [],
+            "name": "addVoter",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 134,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 133,
+                  "name": "_nationalID",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 153,
+                  "src": "1318:16:1",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 132,
+                    "name": "uint",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1318:4:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                }
+              ],
+              "src": "1317:18:1"
+            },
+            "payable": false,
+            "returnParameters": {
+              "id": 135,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "1343:0:1"
+            },
+            "scope": 207,
+            "src": "1300:186:1",
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          {
+            "body": {
+              "id": 205,
+              "nodeType": "Block",
+              "src": "1530:564:1",
               "statements": [
                 {
                   "expression": {
@@ -2041,7 +3462,160 @@
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 120,
+                        "commonType": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        },
+                        "id": 165,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftExpression": {
+                          "argumentTypes": null,
+                          "expression": {
+                            "argumentTypes": null,
+                            "baseExpression": {
+                              "argumentTypes": null,
+                              "id": 159,
+                              "name": "voters",
+                              "nodeType": "Identifier",
+                              "overloadedDeclarations": [],
+                              "referencedDeclaration": 84,
+                              "src": "1586:6:1",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+                                "typeString": "mapping(address => struct Election.Voter storage ref)"
+                              }
+                            },
+                            "id": 162,
+                            "indexExpression": {
+                              "argumentTypes": null,
+                              "expression": {
+                                "argumentTypes": null,
+                                "id": 160,
+                                "name": "msg",
+                                "nodeType": "Identifier",
+                                "overloadedDeclarations": [],
+                                "referencedDeclaration": 222,
+                                "src": "1593:3:1",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_magic_message",
+                                  "typeString": "msg"
+                                }
+                              },
+                              "id": 161,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "memberName": "sender",
+                              "nodeType": "MemberAccess",
+                              "referencedDeclaration": null,
+                              "src": "1593:10:1",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_address",
+                                "typeString": "address"
+                              }
+                            },
+                            "isConstant": false,
+                            "isLValue": true,
+                            "isPure": false,
+                            "lValueRequested": false,
+                            "nodeType": "IndexAccess",
+                            "src": "1586:18:1",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_struct$_Voter_$76_storage",
+                              "typeString": "struct Election.Voter storage ref"
+                            }
+                          },
+                          "id": 163,
+                          "isConstant": false,
+                          "isLValue": true,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "memberName": "eligibility",
+                          "nodeType": "MemberAccess",
+                          "referencedDeclaration": 69,
+                          "src": "1586:30:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          }
+                        },
+                        "nodeType": "BinaryOperation",
+                        "operator": "==",
+                        "rightExpression": {
+                          "argumentTypes": null,
+                          "hexValue": "74727565",
+                          "id": 164,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "bool",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "1620:4:1",
+                          "subdenomination": null,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          },
+                          "value": "true"
+                        },
+                        "src": "1586:38:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      ],
+                      "id": 158,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        225,
+                        226
+                      ],
+                      "referencedDeclaration": 225,
+                      "src": "1578:7:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
+                        "typeString": "function (bool) pure"
+                      }
+                    },
+                    "id": 166,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "1578:47:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 167,
+                  "nodeType": "ExpressionStatement",
+                  "src": "1578:47:1"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "arguments": [
+                      {
+                        "argumentTypes": null,
+                        "id": 174,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -2049,58 +3623,74 @@
                         "nodeType": "UnaryOperation",
                         "operator": "!",
                         "prefix": true,
-                        "src": "788:19:1",
+                        "src": "1697:28:1",
                         "subExpression": {
                           "argumentTypes": null,
-                          "baseExpression": {
+                          "expression": {
                             "argumentTypes": null,
-                            "id": 116,
-                            "name": "voters",
-                            "nodeType": "Identifier",
-                            "overloadedDeclarations": [],
-                            "referencedDeclaration": 73,
-                            "src": "789:6:1",
-                            "typeDescriptions": {
-                              "typeIdentifier": "t_mapping$_t_address_$_t_bool_$",
-                              "typeString": "mapping(address => bool)"
-                            }
-                          },
-                          "id": 119,
-                          "indexExpression": {
-                            "argumentTypes": null,
-                            "expression": {
+                            "baseExpression": {
                               "argumentTypes": null,
-                              "id": 117,
-                              "name": "msg",
+                              "id": 169,
+                              "name": "voters",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 167,
-                              "src": "796:3:1",
+                              "referencedDeclaration": 84,
+                              "src": "1698:6:1",
                               "typeDescriptions": {
-                                "typeIdentifier": "t_magic_message",
-                                "typeString": "msg"
+                                "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+                                "typeString": "mapping(address => struct Election.Voter storage ref)"
                               }
                             },
-                            "id": 118,
+                            "id": 172,
+                            "indexExpression": {
+                              "argumentTypes": null,
+                              "expression": {
+                                "argumentTypes": null,
+                                "id": 170,
+                                "name": "msg",
+                                "nodeType": "Identifier",
+                                "overloadedDeclarations": [],
+                                "referencedDeclaration": 222,
+                                "src": "1705:3:1",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_magic_message",
+                                  "typeString": "msg"
+                                }
+                              },
+                              "id": 171,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "memberName": "sender",
+                              "nodeType": "MemberAccess",
+                              "referencedDeclaration": null,
+                              "src": "1705:10:1",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_address",
+                                "typeString": "address"
+                              }
+                            },
                             "isConstant": false,
-                            "isLValue": false,
+                            "isLValue": true,
                             "isPure": false,
                             "lValueRequested": false,
-                            "memberName": "sender",
-                            "nodeType": "MemberAccess",
-                            "referencedDeclaration": null,
-                            "src": "796:10:1",
+                            "nodeType": "IndexAccess",
+                            "src": "1698:18:1",
                             "typeDescriptions": {
-                              "typeIdentifier": "t_address",
-                              "typeString": "address"
+                              "typeIdentifier": "t_struct$_Voter_$76_storage",
+                              "typeString": "struct Election.Voter storage ref"
                             }
                           },
+                          "id": 173,
                           "isConstant": false,
                           "isLValue": true,
                           "isPure": false,
                           "lValueRequested": false,
-                          "nodeType": "IndexAccess",
-                          "src": "789:18:1",
+                          "memberName": "hasVoted",
+                          "nodeType": "MemberAccess",
+                          "referencedDeclaration": 71,
+                          "src": "1698:27:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
@@ -2119,21 +3709,21 @@
                           "typeString": "bool"
                         }
                       ],
-                      "id": 115,
+                      "id": 168,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        170,
-                        171
+                        225,
+                        226
                       ],
-                      "referencedDeclaration": 170,
-                      "src": "780:7:1",
+                      "referencedDeclaration": 225,
+                      "src": "1689:7:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
                         "typeString": "function (bool) pure"
                       }
                     },
-                    "id": 121,
+                    "id": 175,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -2141,15 +3731,15 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "780:28:1",
+                    "src": "1689:37:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 122,
+                  "id": 176,
                   "nodeType": "ExpressionStatement",
-                  "src": "780:28:1"
+                  "src": "1689:37:1"
                 },
                 {
                   "expression": {
@@ -2161,7 +3751,7 @@
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
                         },
-                        "id": 130,
+                        "id": 184,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -2172,19 +3762,19 @@
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
                           },
-                          "id": 126,
+                          "id": 180,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftExpression": {
                             "argumentTypes": null,
-                            "id": 124,
+                            "id": 178,
                             "name": "_candidateId",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 112,
-                            "src": "867:12:1",
+                            "referencedDeclaration": 155,
+                            "src": "1785:12:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
@@ -2195,14 +3785,14 @@
                           "rightExpression": {
                             "argumentTypes": null,
                             "hexValue": "30",
-                            "id": 125,
+                            "id": 179,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
                             "kind": "number",
                             "lValueRequested": false,
                             "nodeType": "Literal",
-                            "src": "882:1:1",
+                            "src": "1800:1:1",
                             "subdenomination": null,
                             "typeDescriptions": {
                               "typeIdentifier": "t_rational_0_by_1",
@@ -2210,7 +3800,7 @@
                             },
                             "value": "0"
                           },
-                          "src": "867:16:1",
+                          "src": "1785:16:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
@@ -2224,19 +3814,19 @@
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
                           },
-                          "id": 129,
+                          "id": 183,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftExpression": {
                             "argumentTypes": null,
-                            "id": 127,
+                            "id": 181,
                             "name": "_candidateId",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 112,
-                            "src": "887:12:1",
+                            "referencedDeclaration": 155,
+                            "src": "1805:12:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
@@ -2246,24 +3836,24 @@
                           "operator": "<=",
                           "rightExpression": {
                             "argumentTypes": null,
-                            "id": 128,
+                            "id": 182,
                             "name": "candidatesCount",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 79,
-                            "src": "903:15:1",
+                            "referencedDeclaration": 90,
+                            "src": "1821:15:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
                             }
                           },
-                          "src": "887:31:1",
+                          "src": "1805:31:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
                           }
                         },
-                        "src": "867:51:1",
+                        "src": "1785:51:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
@@ -2277,21 +3867,21 @@
                           "typeString": "bool"
                         }
                       ],
-                      "id": 123,
+                      "id": 177,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        170,
-                        171
+                        225,
+                        226
                       ],
-                      "referencedDeclaration": 170,
-                      "src": "859:7:1",
+                      "referencedDeclaration": 225,
+                      "src": "1777:7:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
                         "typeString": "function (bool) pure"
                       }
                     },
-                    "id": 131,
+                    "id": 185,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -2299,75 +3889,91 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "859:60:1",
+                    "src": "1777:60:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 132,
+                  "id": 186,
                   "nodeType": "ExpressionStatement",
-                  "src": "859:60:1"
+                  "src": "1777:60:1"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 138,
+                    "id": 193,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "baseExpression": {
+                      "expression": {
                         "argumentTypes": null,
-                        "id": 133,
-                        "name": "voters",
-                        "nodeType": "Identifier",
-                        "overloadedDeclarations": [],
-                        "referencedDeclaration": 73,
-                        "src": "972:6:1",
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_mapping$_t_address_$_t_bool_$",
-                          "typeString": "mapping(address => bool)"
-                        }
-                      },
-                      "id": 136,
-                      "indexExpression": {
-                        "argumentTypes": null,
-                        "expression": {
+                        "baseExpression": {
                           "argumentTypes": null,
-                          "id": 134,
-                          "name": "msg",
+                          "id": 187,
+                          "name": "voters",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 167,
-                          "src": "979:3:1",
+                          "referencedDeclaration": 84,
+                          "src": "1890:6:1",
                           "typeDescriptions": {
-                            "typeIdentifier": "t_magic_message",
-                            "typeString": "msg"
+                            "typeIdentifier": "t_mapping$_t_address_$_t_struct$_Voter_$76_storage_$",
+                            "typeString": "mapping(address => struct Election.Voter storage ref)"
                           }
                         },
-                        "id": 135,
+                        "id": 190,
+                        "indexExpression": {
+                          "argumentTypes": null,
+                          "expression": {
+                            "argumentTypes": null,
+                            "id": 188,
+                            "name": "msg",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 222,
+                            "src": "1897:3:1",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_magic_message",
+                              "typeString": "msg"
+                            }
+                          },
+                          "id": 189,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "memberName": "sender",
+                          "nodeType": "MemberAccess",
+                          "referencedDeclaration": null,
+                          "src": "1897:10:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          }
+                        },
                         "isConstant": false,
-                        "isLValue": false,
+                        "isLValue": true,
                         "isPure": false,
                         "lValueRequested": false,
-                        "memberName": "sender",
-                        "nodeType": "MemberAccess",
-                        "referencedDeclaration": null,
-                        "src": "979:10:1",
+                        "nodeType": "IndexAccess",
+                        "src": "1890:18:1",
                         "typeDescriptions": {
-                          "typeIdentifier": "t_address",
-                          "typeString": "address"
+                          "typeIdentifier": "t_struct$_Voter_$76_storage",
+                          "typeString": "struct Election.Voter storage ref"
                         }
                       },
+                      "id": 191,
                       "isConstant": false,
                       "isLValue": true,
                       "isPure": false,
                       "lValueRequested": true,
-                      "nodeType": "IndexAccess",
-                      "src": "972:18:1",
+                      "memberName": "hasVoted",
+                      "nodeType": "MemberAccess",
+                      "referencedDeclaration": 71,
+                      "src": "1890:27:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
                         "typeString": "bool"
@@ -2378,14 +3984,14 @@
                     "rightHandSide": {
                       "argumentTypes": null,
                       "hexValue": "74727565",
-                      "id": 137,
+                      "id": 192,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "kind": "bool",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "993:4:1",
+                      "src": "1920:4:1",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
@@ -2393,20 +3999,20 @@
                       },
                       "value": "true"
                     },
-                    "src": "972:25:1",
+                    "src": "1890:34:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
-                  "id": 139,
+                  "id": 194,
                   "nodeType": "ExpressionStatement",
-                  "src": "972:25:1"
+                  "src": "1890:34:1"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 144,
+                    "id": 199,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -2414,33 +4020,33 @@
                     "nodeType": "UnaryOperation",
                     "operator": "++",
                     "prefix": false,
-                    "src": "1050:36:1",
+                    "src": "1977:36:1",
                     "subExpression": {
                       "argumentTypes": null,
                       "expression": {
                         "argumentTypes": null,
                         "baseExpression": {
                           "argumentTypes": null,
-                          "id": 140,
+                          "id": 195,
                           "name": "candidates",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 69,
-                          "src": "1050:10:1",
+                          "referencedDeclaration": 80,
+                          "src": "1977:10:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_uint256_$_t_struct$_Candidate_$65_storage_$",
                             "typeString": "mapping(uint256 => struct Election.Candidate storage ref)"
                           }
                         },
-                        "id": 142,
+                        "id": 197,
                         "indexExpression": {
                           "argumentTypes": null,
-                          "id": 141,
+                          "id": 196,
                           "name": "_candidateId",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 112,
-                          "src": "1061:12:1",
+                          "referencedDeclaration": 155,
+                          "src": "1988:12:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
@@ -2451,13 +4057,13 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "1050:24:1",
+                        "src": "1977:24:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_struct$_Candidate_$65_storage",
                           "typeString": "struct Election.Candidate storage ref"
                         }
                       },
-                      "id": 143,
+                      "id": 198,
                       "isConstant": false,
                       "isLValue": true,
                       "isPure": false,
@@ -2465,7 +4071,7 @@
                       "memberName": "voteCount",
                       "nodeType": "MemberAccess",
                       "referencedDeclaration": 64,
-                      "src": "1050:34:1",
+                      "src": "1977:34:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
@@ -2476,22 +4082,22 @@
                       "typeString": "uint256"
                     }
                   },
-                  "id": 145,
+                  "id": 200,
                   "nodeType": "ExpressionStatement",
-                  "src": "1050:36:1"
+                  "src": "1977:36:1"
                 },
                 {
-                  "expression": {
+                  "eventCall": {
                     "argumentTypes": null,
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 147,
+                        "id": 202,
                         "name": "_candidateId",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 112,
-                        "src": "1141:12:1",
+                        "referencedDeclaration": 155,
+                        "src": "2073:12:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
@@ -2505,18 +4111,18 @@
                           "typeString": "uint256"
                         }
                       ],
-                      "id": 146,
+                      "id": 201,
                       "name": "votedEvent",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 77,
-                      "src": "1130:10:1",
+                      "referencedDeclaration": 88,
+                      "src": "2062:10:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_event_nonpayable$_t_uint256_$returns$__$",
                         "typeString": "function (uint256)"
                       }
                     },
-                    "id": 148,
+                    "id": 203,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -2524,20 +4130,20 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1130:24:1",
+                    "src": "2062:24:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 149,
-                  "nodeType": "ExpressionStatement",
-                  "src": "1130:24:1"
+                  "id": 204,
+                  "nodeType": "EmitStatement",
+                  "src": "2057:29:1"
                 }
               ]
             },
             "documentation": null,
-            "id": 151,
+            "id": 206,
             "implemented": true,
             "isConstructor": false,
             "isDeclaredConst": false,
@@ -2545,16 +4151,16 @@
             "name": "vote",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 113,
+              "id": 156,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 112,
+                  "id": 155,
                   "name": "_candidateId",
                   "nodeType": "VariableDeclaration",
-                  "scope": 151,
-                  "src": "692:17:1",
+                  "scope": 206,
+                  "src": "1504:17:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2562,10 +4168,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 111,
+                    "id": 154,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
-                    "src": "692:4:1",
+                    "src": "1504:4:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -2575,27 +4181,27 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "691:19:1"
+              "src": "1503:19:1"
             },
             "payable": false,
             "returnParameters": {
-              "id": 114,
+              "id": 157,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "718:0:1"
+              "src": "1530:0:1"
             },
-            "scope": 152,
-            "src": "678:484:1",
+            "scope": 207,
+            "src": "1490:604:1",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
           }
         ],
-        "scope": 153,
-        "src": "27:1138:1"
+        "scope": 208,
+        "src": "27:2070:1"
       }
     ],
-    "src": "0:1167:1"
+    "src": "0:2099:1"
   },
   "compiler": {
     "name": "solc",
@@ -2619,12 +4225,12 @@
         }
       },
       "links": {},
-      "address": "0xCC39872B1e2cE3A0201E4030D73041AC46E6ff09",
-      "transactionHash": "0x3a5e19ac60ce61bb2de41c103a5f298cb4f0d60e3df7fe6cf1510e5ae12415e5"
+      "address": "0x1663C43c772e9d12Bee23e988225d386ee3b965E",
+      "transactionHash": "0xa299a0f8b279e37320ed0393e051ae4ea18dbf0c7e03a2de588b5cc19ea41a73"
     }
   },
   "schemaVersion": "3.0.22",
-  "updatedAt": "2020-07-29T12:49:50.927Z",
+  "updatedAt": "2020-08-06T14:54:56.112Z",
   "networkType": "ethereum",
   "devdoc": {
     "methods": {}

--- a/build/contracts/Migrations.json
+++ b/build/contracts/Migrations.json
@@ -183,7 +183,7 @@
                         "name": "msg",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 167,
+                        "referencedDeclaration": 222,
                         "src": "153:3:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_magic_message",
@@ -287,7 +287,7 @@
                         "name": "msg",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 167,
+                        "referencedDeclaration": 222,
                         "src": "223:3:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_magic_message",
@@ -833,7 +833,7 @@
                         "name": "msg",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 167,
+                        "referencedDeclaration": 222,
                         "src": "153:3:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_magic_message",
@@ -937,7 +937,7 @@
                         "name": "msg",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 167,
+                        "referencedDeclaration": 222,
                         "src": "223:3:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_magic_message",
@@ -1379,12 +1379,12 @@
     "5777": {
       "events": {},
       "links": {},
-      "address": "0x996Ea70f632C820dD01f270B75FFB43D373c2618",
-      "transactionHash": "0xb02eb7d54e85d7e9f66c38e2739cf4f1d1e4e330799225d616c8836e2b6ac70e"
+      "address": "0xB210e322439e2e9ce5E5CEBd6Bcc7DbE5176c300",
+      "transactionHash": "0x63be2a9df6c991b40f2d6b8e82048834599360bff0babd30494ca49b6b56ca94"
     }
   },
   "schemaVersion": "3.0.22",
-  "updatedAt": "2020-07-29T12:49:50.929Z",
+  "updatedAt": "2020-08-06T14:54:56.115Z",
   "networkType": "ethereum",
   "devdoc": {
     "methods": {}

--- a/build/contracts/Migrations.json
+++ b/build/contracts/Migrations.json
@@ -1379,12 +1379,12 @@
     "5777": {
       "events": {},
       "links": {},
-      "address": "0xD91C7F5f4a0a037b3b9e7b67fDF63ABf77bFe8b9",
-      "transactionHash": "0x9ffc915bfbd36687dd84263f1619d8bb5892396358291fa68a36738f3415eb65"
+      "address": "0x13a2808b538E8f34364099e782F4a584899BB80a",
+      "transactionHash": "0x40f8773f351fd8ecda5134eb738e30b096c6907fd1dadd8ecdb4e48b38861019"
     }
   },
   "schemaVersion": "3.0.22",
-  "updatedAt": "2020-08-07T21:10:55.885Z",
+  "updatedAt": "2020-08-08T16:38:26.056Z",
   "networkType": "ethereum",
   "devdoc": {
     "methods": {}

--- a/build/contracts/Migrations.json
+++ b/build/contracts/Migrations.json
@@ -64,12 +64,12 @@
       "type": "function"
     }
   ],
-  "metadata": "{\"compiler\":{\"version\":\"0.4.23+commit.124ca40d\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"constant\":false,\"inputs\":[{\"name\":\"new_address\",\"type\":\"address\"}],\"name\":\"upgrade\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"last_completed_migration\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"completed\",\"type\":\"uint256\"}],\"name\":\"setCompleted\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"}],\"devdoc\":{\"methods\":{}},\"userdoc\":{\"methods\":{}}},\"settings\":{\"compilationTarget\":{\"/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/Migration.sol\":\"Migrations\"},\"evmVersion\":\"byzantium\",\"libraries\":{},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/Migration.sol\":{\"keccak256\":\"0x8f97f024866777f0321982981c0ac920ad7640ad747712356ee8ccb1a5e600e8\",\"urls\":[\"bzzr://cca0a8cfc59efe6c316129491e068ad2c92af19c400750c08809abbc6bbd9686\"]}},\"version\":1}",
-  "bytecode": "0x608060405234801561001057600080fd5b50336000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055506102f8806100606000396000f300608060405260043610610062576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630900f01014610067578063445df0ac146100aa5780638da5cb5b146100d5578063fdacd5761461012c575b600080fd5b34801561007357600080fd5b506100a8600480360381019080803573ffffffffffffffffffffffffffffffffffffffff169060200190929190505050610159565b005b3480156100b657600080fd5b506100bf610241565b6040518082815260200191505060405180910390f35b3480156100e157600080fd5b506100ea610247565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b34801561013857600080fd5b506101576004803603810190808035906020019092919050505061026c565b005b60008060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16141561023d578190508073ffffffffffffffffffffffffffffffffffffffff1663fdacd5766001546040518263ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040180828152602001915050600060405180830381600087803b15801561022457600080fd5b505af1158015610238573d6000803e3d6000fd5b505050505b5050565b60015481565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614156102c957806001819055505b505600a165627a7a723058209d5fb08e2e89a9a1b41adc278ad9bf638b2e4960e58458507576b424fd62f3cf0029",
-  "deployedBytecode": "0x608060405260043610610062576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630900f01014610067578063445df0ac146100aa5780638da5cb5b146100d5578063fdacd5761461012c575b600080fd5b34801561007357600080fd5b506100a8600480360381019080803573ffffffffffffffffffffffffffffffffffffffff169060200190929190505050610159565b005b3480156100b657600080fd5b506100bf610241565b6040518082815260200191505060405180910390f35b3480156100e157600080fd5b506100ea610247565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b34801561013857600080fd5b506101576004803603810190808035906020019092919050505061026c565b005b60008060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16141561023d578190508073ffffffffffffffffffffffffffffffffffffffff1663fdacd5766001546040518263ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040180828152602001915050600060405180830381600087803b15801561022457600080fd5b505af1158015610238573d6000803e3d6000fd5b505050505b5050565b60015481565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614156102c957806001819055505b505600a165627a7a723058209d5fb08e2e89a9a1b41adc278ad9bf638b2e4960e58458507576b424fd62f3cf0029",
-  "sourceMap": "27:500:0:-;;;187:52;8:9:-1;5:2;;;30:1;27;20:12;5:2;187:52:0;223:10;215:5;;:18;;;;;;;;;;;;;;;;;;27:500;;;;;;",
-  "deployedSourceMap": "27:500:0:-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;356:168;;8:9:-1;5:2;;;30:1;27;20:12;5:2;356:168:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;77:36;;8:9:-1;5:2;;;30:1;27;20:12;5:2;77:36:0;;;;;;;;;;;;;;;;;;;;;;;52:20;;8:9:-1;5:2;;;30:1;27;20:12;5:2;52:20:0;;;;;;;;;;;;;;;;;;;;;;;;;;;245:105;;8:9:-1;5:2;;;30:1;27;20:12;5:2;245:105:0;;;;;;;;;;;;;;;;;;;;;;;;;;356:168;419:19;167:5;;;;;;;;;;;153:19;;:10;:19;;;149:26;;;452:11;419:45;;471:8;:21;;;493:24;;471:47;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;471:47:0;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;471:47:0;;;;149:26;356:168;;:::o;77:36::-;;;;:::o;52:20::-;;;;;;;;;;;;;:::o;245:105::-;167:5;;;;;;;;;;;153:19;;:10;:19;;;149:26;;;335:9;308:24;:36;;;;149:26;245:105;:::o",
-  "source": "pragma solidity ^0.4.2;\r\n\r\ncontract Migrations {\r\n  address public owner;\r\n  uint public last_completed_migration;\r\n\r\n  modifier restricted() {\r\n    if (msg.sender == owner) _;\r\n  }\r\n\r\n  constructor() public {\r\n    owner = msg.sender;\r\n  }\r\n\r\n  function setCompleted(uint completed) public restricted {\r\n    last_completed_migration = completed;\r\n  }\r\n\r\n  function upgrade(address new_address) public restricted {\r\n    Migrations upgraded = Migrations(new_address);\r\n    upgraded.setCompleted(last_completed_migration);\r\n  }\r\n}\r\n",
+  "metadata": "{\"compiler\":{\"version\":\"0.4.23+commit.124ca40d\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"constant\":false,\"inputs\":[{\"name\":\"new_address\",\"type\":\"address\"}],\"name\":\"upgrade\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"last_completed_migration\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"completed\",\"type\":\"uint256\"}],\"name\":\"setCompleted\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"}],\"devdoc\":{\"methods\":{}},\"userdoc\":{\"methods\":{}}},\"settings\":{\"compilationTarget\":{\"/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/Migration.sol\":\"Migrations\"},\"evmVersion\":\"byzantium\",\"libraries\":{},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/Migration.sol\":{\"keccak256\":\"0x2e5fda288f9ffb4841eb08f41a8194ad169f297e236f7acc463ad6a95cb4950b\",\"urls\":[\"bzzr://9505dfc18709118dd6f9d59f634610333e6df25b31b8a0072f1ee1f76e133caa\"]}},\"version\":1}",
+  "bytecode": "0x608060405234801561001057600080fd5b50336000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055506102f8806100606000396000f300608060405260043610610062576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630900f01014610067578063445df0ac146100aa5780638da5cb5b146100d5578063fdacd5761461012c575b600080fd5b34801561007357600080fd5b506100a8600480360381019080803573ffffffffffffffffffffffffffffffffffffffff169060200190929190505050610159565b005b3480156100b657600080fd5b506100bf610241565b6040518082815260200191505060405180910390f35b3480156100e157600080fd5b506100ea610247565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b34801561013857600080fd5b506101576004803603810190808035906020019092919050505061026c565b005b60008060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16141561023d578190508073ffffffffffffffffffffffffffffffffffffffff1663fdacd5766001546040518263ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040180828152602001915050600060405180830381600087803b15801561022457600080fd5b505af1158015610238573d6000803e3d6000fd5b505050505b5050565b60015481565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614156102c957806001819055505b505600a165627a7a723058209275762e1ed669e9d215237b30009a7a15f0d1dacd693328bb5748d05d2b6b400029",
+  "deployedBytecode": "0x608060405260043610610062576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630900f01014610067578063445df0ac146100aa5780638da5cb5b146100d5578063fdacd5761461012c575b600080fd5b34801561007357600080fd5b506100a8600480360381019080803573ffffffffffffffffffffffffffffffffffffffff169060200190929190505050610159565b005b3480156100b657600080fd5b506100bf610241565b6040518082815260200191505060405180910390f35b3480156100e157600080fd5b506100ea610247565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b34801561013857600080fd5b506101576004803603810190808035906020019092919050505061026c565b005b60008060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16141561023d578190508073ffffffffffffffffffffffffffffffffffffffff1663fdacd5766001546040518263ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040180828152602001915050600060405180830381600087803b15801561022457600080fd5b505af1158015610238573d6000803e3d6000fd5b505050505b5050565b60015481565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614156102c957806001819055505b505600a165627a7a723058209275762e1ed669e9d215237b30009a7a15f0d1dacd693328bb5748d05d2b6b400029",
+  "sourceMap": "28:500:0:-;;;188:52;8:9:-1;5:2;;;30:1;27;20:12;5:2;188:52:0;224:10;216:5;;:18;;;;;;;;;;;;;;;;;;28:500;;;;;;",
+  "deployedSourceMap": "28:500:0:-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;357:168;;8:9:-1;5:2;;;30:1;27;20:12;5:2;357:168:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;78:36;;8:9:-1;5:2;;;30:1;27;20:12;5:2;78:36:0;;;;;;;;;;;;;;;;;;;;;;;53:20;;8:9:-1;5:2;;;30:1;27;20:12;5:2;53:20:0;;;;;;;;;;;;;;;;;;;;;;;;;;;246:105;;8:9:-1;5:2;;;30:1;27;20:12;5:2;246:105:0;;;;;;;;;;;;;;;;;;;;;;;;;;357:168;420:19;168:5;;;;;;;;;;;154:19;;:10;:19;;;150:26;;;453:11;420:45;;472:8;:21;;;494:24;;472:47;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;472:47:0;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;472:47:0;;;;150:26;357:168;;:::o;78:36::-;;;;:::o;53:20::-;;;;;;;;;;;;;:::o;246:105::-;168:5;;;;;;;;;;;154:19;;:10;:19;;;150:26;;;336:9;309:24;:36;;;;150:26;246:105;:::o",
+  "source": "pragma solidity ^0.4.23;\r\n\r\ncontract Migrations {\r\n  address public owner;\r\n  uint public last_completed_migration;\r\n\r\n  modifier restricted() {\r\n    if (msg.sender == owner) _;\r\n  }\r\n\r\n  constructor() public {\r\n    owner = msg.sender;\r\n  }\r\n\r\n  function setCompleted(uint completed) public restricted {\r\n    last_completed_migration = completed;\r\n  }\r\n\r\n  function upgrade(address new_address) public restricted {\r\n    Migrations upgraded = Migrations(new_address);\r\n    upgraded.setCompleted(last_completed_migration);\r\n  }\r\n}\r\n",
   "sourcePath": "L:/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/Migration.sol",
   "ast": {
     "absolutePath": "/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/Migration.sol",
@@ -87,10 +87,10 @@
           "solidity",
           "^",
           "0.4",
-          ".2"
+          ".23"
         ],
         "nodeType": "PragmaDirective",
-        "src": "0:23:0"
+        "src": "0:24:0"
       },
       {
         "baseContracts": [],
@@ -111,7 +111,7 @@
             "name": "owner",
             "nodeType": "VariableDeclaration",
             "scope": 56,
-            "src": "52:20:0",
+            "src": "53:20:0",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -122,7 +122,7 @@
               "id": 2,
               "name": "address",
               "nodeType": "ElementaryTypeName",
-              "src": "52:7:0",
+              "src": "53:7:0",
               "typeDescriptions": {
                 "typeIdentifier": "t_address",
                 "typeString": "address"
@@ -137,7 +137,7 @@
             "name": "last_completed_migration",
             "nodeType": "VariableDeclaration",
             "scope": 56,
-            "src": "77:36:0",
+            "src": "78:36:0",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -148,7 +148,7 @@
               "id": 4,
               "name": "uint",
               "nodeType": "ElementaryTypeName",
-              "src": "77:4:0",
+              "src": "78:4:0",
               "typeDescriptions": {
                 "typeIdentifier": "t_uint256",
                 "typeString": "uint256"
@@ -161,7 +161,7 @@
             "body": {
               "id": 13,
               "nodeType": "Block",
-              "src": "142:39:0",
+              "src": "143:39:0",
               "statements": [
                 {
                   "condition": {
@@ -183,8 +183,8 @@
                         "name": "msg",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 222,
-                        "src": "153:3:0",
+                        "referencedDeclaration": 240,
+                        "src": "154:3:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_magic_message",
                           "typeString": "msg"
@@ -198,7 +198,7 @@
                       "memberName": "sender",
                       "nodeType": "MemberAccess",
                       "referencedDeclaration": null,
-                      "src": "153:10:0",
+                      "src": "154:10:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
@@ -213,13 +213,13 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 3,
-                      "src": "167:5:0",
+                      "src": "168:5:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
                       }
                     },
-                    "src": "153:19:0",
+                    "src": "154:19:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
@@ -228,11 +228,11 @@
                   "falseBody": null,
                   "id": 12,
                   "nodeType": "IfStatement",
-                  "src": "149:26:0",
+                  "src": "150:26:0",
                   "trueBody": {
                     "id": 11,
                     "nodeType": "PlaceholderStatement",
-                    "src": "174:1:0"
+                    "src": "175:1:0"
                   }
                 }
               ]
@@ -245,16 +245,16 @@
               "id": 6,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "139:2:0"
+              "src": "140:2:0"
             },
-            "src": "120:61:0",
+            "src": "121:61:0",
             "visibility": "internal"
           },
           {
             "body": {
               "id": 22,
               "nodeType": "Block",
-              "src": "208:31:0",
+              "src": "209:31:0",
               "statements": [
                 {
                   "expression": {
@@ -271,7 +271,7 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 3,
-                      "src": "215:5:0",
+                      "src": "216:5:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
@@ -287,8 +287,8 @@
                         "name": "msg",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 222,
-                        "src": "223:3:0",
+                        "referencedDeclaration": 240,
+                        "src": "224:3:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_magic_message",
                           "typeString": "msg"
@@ -302,13 +302,13 @@
                       "memberName": "sender",
                       "nodeType": "MemberAccess",
                       "referencedDeclaration": null,
-                      "src": "223:10:0",
+                      "src": "224:10:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
                       }
                     },
-                    "src": "215:18:0",
+                    "src": "216:18:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
@@ -316,7 +316,7 @@
                   },
                   "id": 21,
                   "nodeType": "ExpressionStatement",
-                  "src": "215:18:0"
+                  "src": "216:18:0"
                 }
               ]
             },
@@ -332,17 +332,17 @@
               "id": 15,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "198:2:0"
+              "src": "199:2:0"
             },
             "payable": false,
             "returnParameters": {
               "id": 16,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "208:0:0"
+              "src": "209:0:0"
             },
             "scope": 56,
-            "src": "187:52:0",
+            "src": "188:52:0",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
@@ -351,7 +351,7 @@
             "body": {
               "id": 34,
               "nodeType": "Block",
-              "src": "301:49:0",
+              "src": "302:49:0",
               "statements": [
                 {
                   "expression": {
@@ -368,7 +368,7 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 5,
-                      "src": "308:24:0",
+                      "src": "309:24:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
@@ -383,13 +383,13 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 25,
-                      "src": "335:9:0",
+                      "src": "336:9:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
                       }
                     },
-                    "src": "308:36:0",
+                    "src": "309:36:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -397,7 +397,7 @@
                   },
                   "id": 33,
                   "nodeType": "ExpressionStatement",
-                  "src": "308:36:0"
+                  "src": "309:36:0"
                 }
               ]
             },
@@ -417,14 +417,14 @@
                   "nodeType": "Identifier",
                   "overloadedDeclarations": [],
                   "referencedDeclaration": 14,
-                  "src": "290:10:0",
+                  "src": "291:10:0",
                   "typeDescriptions": {
                     "typeIdentifier": "t_modifier$__$",
                     "typeString": "modifier ()"
                   }
                 },
                 "nodeType": "ModifierInvocation",
-                "src": "290:10:0"
+                "src": "291:10:0"
               }
             ],
             "name": "setCompleted",
@@ -439,7 +439,7 @@
                   "name": "completed",
                   "nodeType": "VariableDeclaration",
                   "scope": 35,
-                  "src": "267:14:0",
+                  "src": "268:14:0",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -450,7 +450,7 @@
                     "id": 24,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
-                    "src": "267:4:0",
+                    "src": "268:4:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -460,17 +460,17 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "266:16:0"
+              "src": "267:16:0"
             },
             "payable": false,
             "returnParameters": {
               "id": 29,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "301:0:0"
+              "src": "302:0:0"
             },
             "scope": 56,
-            "src": "245:105:0",
+            "src": "246:105:0",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
@@ -479,7 +479,7 @@
             "body": {
               "id": 54,
               "nodeType": "Block",
-              "src": "412:112:0",
+              "src": "413:112:0",
               "statements": [
                 {
                   "assignments": [
@@ -492,7 +492,7 @@
                       "name": "upgraded",
                       "nodeType": "VariableDeclaration",
                       "scope": 55,
-                      "src": "419:19:0",
+                      "src": "420:19:0",
                       "stateVariable": false,
                       "storageLocation": "default",
                       "typeDescriptions": {
@@ -505,7 +505,7 @@
                         "name": "Migrations",
                         "nodeType": "UserDefinedTypeName",
                         "referencedDeclaration": 56,
-                        "src": "419:10:0",
+                        "src": "420:10:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_contract$_Migrations_$56",
                           "typeString": "contract Migrations"
@@ -526,7 +526,7 @@
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 37,
-                        "src": "452:11:0",
+                        "src": "453:11:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
                           "typeString": "address"
@@ -545,7 +545,7 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 56,
-                      "src": "441:10:0",
+                      "src": "442:10:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_type$_t_contract$_Migrations_$56_$",
                         "typeString": "type(contract Migrations)"
@@ -559,14 +559,14 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "441:23:0",
+                    "src": "442:23:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_contract$_Migrations_$56",
                       "typeString": "contract Migrations"
                     }
                   },
                   "nodeType": "VariableDeclarationStatement",
-                  "src": "419:45:0"
+                  "src": "420:45:0"
                 },
                 {
                   "expression": {
@@ -579,7 +579,7 @@
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 5,
-                        "src": "493:24:0",
+                        "src": "494:24:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
@@ -600,7 +600,7 @@
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 43,
-                        "src": "471:8:0",
+                        "src": "472:8:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_contract$_Migrations_$56",
                           "typeString": "contract Migrations"
@@ -614,7 +614,7 @@
                       "memberName": "setCompleted",
                       "nodeType": "MemberAccess",
                       "referencedDeclaration": 35,
-                      "src": "471:21:0",
+                      "src": "472:21:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_external_nonpayable$_t_uint256_$returns$__$",
                         "typeString": "function (uint256) external"
@@ -628,7 +628,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "471:47:0",
+                    "src": "472:47:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
@@ -636,7 +636,7 @@
                   },
                   "id": 53,
                   "nodeType": "ExpressionStatement",
-                  "src": "471:47:0"
+                  "src": "472:47:0"
                 }
               ]
             },
@@ -656,14 +656,14 @@
                   "nodeType": "Identifier",
                   "overloadedDeclarations": [],
                   "referencedDeclaration": 14,
-                  "src": "401:10:0",
+                  "src": "402:10:0",
                   "typeDescriptions": {
                     "typeIdentifier": "t_modifier$__$",
                     "typeString": "modifier ()"
                   }
                 },
                 "nodeType": "ModifierInvocation",
-                "src": "401:10:0"
+                "src": "402:10:0"
               }
             ],
             "name": "upgrade",
@@ -678,7 +678,7 @@
                   "name": "new_address",
                   "nodeType": "VariableDeclaration",
                   "scope": 55,
-                  "src": "373:19:0",
+                  "src": "374:19:0",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -689,7 +689,7 @@
                     "id": 36,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "373:7:0",
+                    "src": "374:7:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
@@ -699,27 +699,27 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "372:21:0"
+              "src": "373:21:0"
             },
             "payable": false,
             "returnParameters": {
               "id": 41,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "412:0:0"
+              "src": "413:0:0"
             },
             "scope": 56,
-            "src": "356:168:0",
+            "src": "357:168:0",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
           }
         ],
         "scope": 57,
-        "src": "27:500:0"
+        "src": "28:500:0"
       }
     ],
-    "src": "0:529:0"
+    "src": "0:530:0"
   },
   "legacyAST": {
     "absolutePath": "/L/Personal Works/Student Code-In/Smart-Contracts-Migration/Blockchain-project/contracts/Migration.sol",
@@ -737,10 +737,10 @@
           "solidity",
           "^",
           "0.4",
-          ".2"
+          ".23"
         ],
         "nodeType": "PragmaDirective",
-        "src": "0:23:0"
+        "src": "0:24:0"
       },
       {
         "baseContracts": [],
@@ -761,7 +761,7 @@
             "name": "owner",
             "nodeType": "VariableDeclaration",
             "scope": 56,
-            "src": "52:20:0",
+            "src": "53:20:0",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -772,7 +772,7 @@
               "id": 2,
               "name": "address",
               "nodeType": "ElementaryTypeName",
-              "src": "52:7:0",
+              "src": "53:7:0",
               "typeDescriptions": {
                 "typeIdentifier": "t_address",
                 "typeString": "address"
@@ -787,7 +787,7 @@
             "name": "last_completed_migration",
             "nodeType": "VariableDeclaration",
             "scope": 56,
-            "src": "77:36:0",
+            "src": "78:36:0",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -798,7 +798,7 @@
               "id": 4,
               "name": "uint",
               "nodeType": "ElementaryTypeName",
-              "src": "77:4:0",
+              "src": "78:4:0",
               "typeDescriptions": {
                 "typeIdentifier": "t_uint256",
                 "typeString": "uint256"
@@ -811,7 +811,7 @@
             "body": {
               "id": 13,
               "nodeType": "Block",
-              "src": "142:39:0",
+              "src": "143:39:0",
               "statements": [
                 {
                   "condition": {
@@ -833,8 +833,8 @@
                         "name": "msg",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 222,
-                        "src": "153:3:0",
+                        "referencedDeclaration": 240,
+                        "src": "154:3:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_magic_message",
                           "typeString": "msg"
@@ -848,7 +848,7 @@
                       "memberName": "sender",
                       "nodeType": "MemberAccess",
                       "referencedDeclaration": null,
-                      "src": "153:10:0",
+                      "src": "154:10:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
@@ -863,13 +863,13 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 3,
-                      "src": "167:5:0",
+                      "src": "168:5:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
                       }
                     },
-                    "src": "153:19:0",
+                    "src": "154:19:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
@@ -878,11 +878,11 @@
                   "falseBody": null,
                   "id": 12,
                   "nodeType": "IfStatement",
-                  "src": "149:26:0",
+                  "src": "150:26:0",
                   "trueBody": {
                     "id": 11,
                     "nodeType": "PlaceholderStatement",
-                    "src": "174:1:0"
+                    "src": "175:1:0"
                   }
                 }
               ]
@@ -895,16 +895,16 @@
               "id": 6,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "139:2:0"
+              "src": "140:2:0"
             },
-            "src": "120:61:0",
+            "src": "121:61:0",
             "visibility": "internal"
           },
           {
             "body": {
               "id": 22,
               "nodeType": "Block",
-              "src": "208:31:0",
+              "src": "209:31:0",
               "statements": [
                 {
                   "expression": {
@@ -921,7 +921,7 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 3,
-                      "src": "215:5:0",
+                      "src": "216:5:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
@@ -937,8 +937,8 @@
                         "name": "msg",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 222,
-                        "src": "223:3:0",
+                        "referencedDeclaration": 240,
+                        "src": "224:3:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_magic_message",
                           "typeString": "msg"
@@ -952,13 +952,13 @@
                       "memberName": "sender",
                       "nodeType": "MemberAccess",
                       "referencedDeclaration": null,
-                      "src": "223:10:0",
+                      "src": "224:10:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
                       }
                     },
-                    "src": "215:18:0",
+                    "src": "216:18:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
@@ -966,7 +966,7 @@
                   },
                   "id": 21,
                   "nodeType": "ExpressionStatement",
-                  "src": "215:18:0"
+                  "src": "216:18:0"
                 }
               ]
             },
@@ -982,17 +982,17 @@
               "id": 15,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "198:2:0"
+              "src": "199:2:0"
             },
             "payable": false,
             "returnParameters": {
               "id": 16,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "208:0:0"
+              "src": "209:0:0"
             },
             "scope": 56,
-            "src": "187:52:0",
+            "src": "188:52:0",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
@@ -1001,7 +1001,7 @@
             "body": {
               "id": 34,
               "nodeType": "Block",
-              "src": "301:49:0",
+              "src": "302:49:0",
               "statements": [
                 {
                   "expression": {
@@ -1018,7 +1018,7 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 5,
-                      "src": "308:24:0",
+                      "src": "309:24:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
@@ -1033,13 +1033,13 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 25,
-                      "src": "335:9:0",
+                      "src": "336:9:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
                       }
                     },
-                    "src": "308:36:0",
+                    "src": "309:36:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -1047,7 +1047,7 @@
                   },
                   "id": 33,
                   "nodeType": "ExpressionStatement",
-                  "src": "308:36:0"
+                  "src": "309:36:0"
                 }
               ]
             },
@@ -1067,14 +1067,14 @@
                   "nodeType": "Identifier",
                   "overloadedDeclarations": [],
                   "referencedDeclaration": 14,
-                  "src": "290:10:0",
+                  "src": "291:10:0",
                   "typeDescriptions": {
                     "typeIdentifier": "t_modifier$__$",
                     "typeString": "modifier ()"
                   }
                 },
                 "nodeType": "ModifierInvocation",
-                "src": "290:10:0"
+                "src": "291:10:0"
               }
             ],
             "name": "setCompleted",
@@ -1089,7 +1089,7 @@
                   "name": "completed",
                   "nodeType": "VariableDeclaration",
                   "scope": 35,
-                  "src": "267:14:0",
+                  "src": "268:14:0",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1100,7 +1100,7 @@
                     "id": 24,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
-                    "src": "267:4:0",
+                    "src": "268:4:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -1110,17 +1110,17 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "266:16:0"
+              "src": "267:16:0"
             },
             "payable": false,
             "returnParameters": {
               "id": 29,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "301:0:0"
+              "src": "302:0:0"
             },
             "scope": 56,
-            "src": "245:105:0",
+            "src": "246:105:0",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
@@ -1129,7 +1129,7 @@
             "body": {
               "id": 54,
               "nodeType": "Block",
-              "src": "412:112:0",
+              "src": "413:112:0",
               "statements": [
                 {
                   "assignments": [
@@ -1142,7 +1142,7 @@
                       "name": "upgraded",
                       "nodeType": "VariableDeclaration",
                       "scope": 55,
-                      "src": "419:19:0",
+                      "src": "420:19:0",
                       "stateVariable": false,
                       "storageLocation": "default",
                       "typeDescriptions": {
@@ -1155,7 +1155,7 @@
                         "name": "Migrations",
                         "nodeType": "UserDefinedTypeName",
                         "referencedDeclaration": 56,
-                        "src": "419:10:0",
+                        "src": "420:10:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_contract$_Migrations_$56",
                           "typeString": "contract Migrations"
@@ -1176,7 +1176,7 @@
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 37,
-                        "src": "452:11:0",
+                        "src": "453:11:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
                           "typeString": "address"
@@ -1195,7 +1195,7 @@
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 56,
-                      "src": "441:10:0",
+                      "src": "442:10:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_type$_t_contract$_Migrations_$56_$",
                         "typeString": "type(contract Migrations)"
@@ -1209,14 +1209,14 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "441:23:0",
+                    "src": "442:23:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_contract$_Migrations_$56",
                       "typeString": "contract Migrations"
                     }
                   },
                   "nodeType": "VariableDeclarationStatement",
-                  "src": "419:45:0"
+                  "src": "420:45:0"
                 },
                 {
                   "expression": {
@@ -1229,7 +1229,7 @@
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 5,
-                        "src": "493:24:0",
+                        "src": "494:24:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
@@ -1250,7 +1250,7 @@
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 43,
-                        "src": "471:8:0",
+                        "src": "472:8:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_contract$_Migrations_$56",
                           "typeString": "contract Migrations"
@@ -1264,7 +1264,7 @@
                       "memberName": "setCompleted",
                       "nodeType": "MemberAccess",
                       "referencedDeclaration": 35,
-                      "src": "471:21:0",
+                      "src": "472:21:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_external_nonpayable$_t_uint256_$returns$__$",
                         "typeString": "function (uint256) external"
@@ -1278,7 +1278,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "471:47:0",
+                    "src": "472:47:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
@@ -1286,7 +1286,7 @@
                   },
                   "id": 53,
                   "nodeType": "ExpressionStatement",
-                  "src": "471:47:0"
+                  "src": "472:47:0"
                 }
               ]
             },
@@ -1306,14 +1306,14 @@
                   "nodeType": "Identifier",
                   "overloadedDeclarations": [],
                   "referencedDeclaration": 14,
-                  "src": "401:10:0",
+                  "src": "402:10:0",
                   "typeDescriptions": {
                     "typeIdentifier": "t_modifier$__$",
                     "typeString": "modifier ()"
                   }
                 },
                 "nodeType": "ModifierInvocation",
-                "src": "401:10:0"
+                "src": "402:10:0"
               }
             ],
             "name": "upgrade",
@@ -1328,7 +1328,7 @@
                   "name": "new_address",
                   "nodeType": "VariableDeclaration",
                   "scope": 55,
-                  "src": "373:19:0",
+                  "src": "374:19:0",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1339,7 +1339,7 @@
                     "id": 36,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "373:7:0",
+                    "src": "374:7:0",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
@@ -1349,27 +1349,27 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "372:21:0"
+              "src": "373:21:0"
             },
             "payable": false,
             "returnParameters": {
               "id": 41,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "412:0:0"
+              "src": "413:0:0"
             },
             "scope": 56,
-            "src": "356:168:0",
+            "src": "357:168:0",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
           }
         ],
         "scope": 57,
-        "src": "27:500:0"
+        "src": "28:500:0"
       }
     ],
-    "src": "0:529:0"
+    "src": "0:530:0"
   },
   "compiler": {
     "name": "solc",
@@ -1379,12 +1379,12 @@
     "5777": {
       "events": {},
       "links": {},
-      "address": "0xB210e322439e2e9ce5E5CEBd6Bcc7DbE5176c300",
-      "transactionHash": "0x63be2a9df6c991b40f2d6b8e82048834599360bff0babd30494ca49b6b56ca94"
+      "address": "0xD91C7F5f4a0a037b3b9e7b67fDF63ABf77bFe8b9",
+      "transactionHash": "0x9ffc915bfbd36687dd84263f1619d8bb5892396358291fa68a36738f3415eb65"
     }
   },
   "schemaVersion": "3.0.22",
-  "updatedAt": "2020-08-06T14:54:56.115Z",
+  "updatedAt": "2020-08-07T21:10:55.885Z",
   "networkType": "ethereum",
   "devdoc": {
     "methods": {}

--- a/contracts/Migration.sol
+++ b/contracts/Migration.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.2;
+pragma solidity ^0.4.23;
 
 contract Migrations {
   address public owner;

--- a/contracts/election.sol
+++ b/contracts/election.sol
@@ -7,44 +7,65 @@ contract Election {
 	string name;
 	uint voteCount;
 }
-
+//Modle a voter
+struct Voter {
+  uint NID;     // govt issued national identification number of candidate
+  bool eligibility;      // stores the valid list of voters during registration
+  bool hasVoted;    // updates when vote is successfully casted on blockchain
+  uint blindedVote;    // stores each voter's hashed vote
+  uint signedBlindedVote;  // blind signature of casted vote
+}
 // Read/write candidates
 mapping(uint => Candidate) public candidates;
 
 // Store accounts that have voted
-mapping(address => bool) public voters;
+mapping(address => Voter) public voters;
 
 // event for logging successful votes
 event votedEvent(
   uint indexed _candidateId
   );
 // Store Candidates Count
-uint public candidatesCount;
+uint public candidatesCount;   // counter cache for candidates
+uint public votersCount;    // counter cache for voters
 
 constructor() public {
 	addCandidate("Candidate 1");
 	addCandidate("Candidate 2");
+  addVoter(100);  // Null NID
+  addVoter(200);
 }
 
+// candidates are pre populated for the election
 function addCandidate(string _name) private {
 candidatesCount++;
 candidates[candidatesCount] = Candidate(candidatesCount, _name, 0);
 }
 
- function vote(uint _candidateId) public {
+// anyone can register for the election
+function addVoter(uint _nationalID) public {
+votersCount++;
+voters[msg.sender] = Voter(_nationalID,true,false,0,0);   // (NID, eligibility, hasVoted, BlindedVote, signedBlindedVote)
+}
+
+function vote(uint _candidateId) public {
+
+        // registered voter check
+        require(voters[msg.sender].eligibility == true);
+
         // require that they haven't voted before
-        require(!voters[msg.sender]);
+        require(!voters[msg.sender].hasVoted);
 
         // require a valid candidate
         require(_candidateId > 0 && _candidateId <= candidatesCount);
 
         // record that voter has voted
-        voters[msg.sender] = true;
+        voters[msg.sender].hasVoted = true;
 
         // update candidate vote Count
         candidates[_candidateId].voteCount++;
 
         //trigger voted event
-        votedEvent(_candidateId);
+        emit votedEvent(_candidateId);
     }
 }

--- a/contracts/election.sol
+++ b/contracts/election.sol
@@ -15,10 +15,10 @@ struct Voter {
   uint blindedVote;    // stores each voter's hashed vote
   uint signedBlindedVote;  // blind signature of casted vote
 }
-// Read/write candidates
+// Candidate ID mapped with candidate struct
 mapping(uint => Candidate) public candidates;
 
-// Store accounts that have voted
+// voter address mapped with voter's details and vote details
 mapping(address => Voter) public voters;
 
 // event for logging successful votes
@@ -26,7 +26,7 @@ event votedEvent(
   uint indexed _candidateId
   );
 
-// event for logging successful votes
+// event for logging successful voter registration
 event newVoter(
   uint indexed _nationalID
 );
@@ -34,22 +34,15 @@ event newVoter(
 uint public candidatesCount;   // counter cache for candidates
 uint public votersCount;    // counter cache for voters
 
-// DEMO Voter accounts
-// voter-1 : 0x793ab88bDa1029b65737D71a2402f18D15C09AC8
-// voter-2 : 0xD8b33BF7080dF17888690fa6092300DEd6C19fC8
 constructor() public {
 
   addCandidate("Candidate 1");
 	addCandidate("Candidate 2");
 //  addVoter(100);   addvoter() function is not used in constructor statement because it invokes require(), but the contract hasn't beem created before constructor call
 //  addVoter(200);
-  /* votersCount++;
-  voters[0x793ab88bDa1029b65737D71a2402f18D15C09AC8] = Voter(100,true,false,0,0); // first demo voter NID - 100
-  votersCount++;
-  voters[0x793ab88bDa1029b65737D71a2402f18D15C09AC8] = Voter(200,true,false,0,0); // second demo voter NID - 200 */
-}
+  }
 
-// candidates are pre populated for the election
+// candidates are pre populated for the election (privately intitialized by the contract)
 function addCandidate(string _name) private {
 candidatesCount++;
 candidates[candidatesCount] = Candidate(candidatesCount, _name, 0);

--- a/contracts/election.sol
+++ b/contracts/election.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.2;
+pragma solidity ^0.4.23;
 
 contract Election {
 // Model a Candidate
@@ -25,15 +25,28 @@ mapping(address => Voter) public voters;
 event votedEvent(
   uint indexed _candidateId
   );
+
+// event for logging successful votes
+event newVoter(
+  uint indexed _nationalID
+);
 // Store Candidates Count
 uint public candidatesCount;   // counter cache for candidates
 uint public votersCount;    // counter cache for voters
 
+// DEMO Voter accounts
+// voter-1 : 0x793ab88bDa1029b65737D71a2402f18D15C09AC8
+// voter-2 : 0xD8b33BF7080dF17888690fa6092300DEd6C19fC8
 constructor() public {
-	addCandidate("Candidate 1");
+
+  addCandidate("Candidate 1");
 	addCandidate("Candidate 2");
-  addVoter(100);  // Null NID
-  addVoter(200);
+//  addVoter(100);   addvoter() function is not used in constructor statement because it invokes require(), but the contract hasn't beem created before constructor call
+//  addVoter(200);
+  /* votersCount++;
+  voters[0x793ab88bDa1029b65737D71a2402f18D15C09AC8] = Voter(100,true,false,0,0); // first demo voter NID - 100
+  votersCount++;
+  voters[0x793ab88bDa1029b65737D71a2402f18D15C09AC8] = Voter(200,true,false,0,0); // second demo voter NID - 200 */
 }
 
 // candidates are pre populated for the election
@@ -44,8 +57,10 @@ candidates[candidatesCount] = Candidate(candidatesCount, _name, 0);
 
 // anyone can register for the election
 function addVoter(uint _nationalID) public {
+require(voters[msg.sender].eligibility == false && voters[msg.sender].NID != _nationalID);  //checks if voter has registered before with same NID / Disallows Double Registration
 votersCount++;
 voters[msg.sender] = Voter(_nationalID,true,false,0,0);   // (NID, eligibility, hasVoted, BlindedVote, signedBlindedVote)
+emit newVoter(_nationalID);
 }
 
 function vote(uint _candidateId) public {

--- a/src/index.html
+++ b/src/index.html
@@ -32,7 +32,18 @@
               </tbody>
             </table>
             <hr/>
-            <form onsubmit="App.castVote(); return false;">
+            <h2 class="text-center" id="registeredVoters">Number of registered voters: <span id="numberOfVoters"></span></h2>
+            <hr/>
+            <form onsubmit="App.createVoter();" id="voterRegistrationForm">      <!-- Voter registration form -->
+              <div class="form-group">
+                <label>Enter National Identification Number: </label>
+                 <input type="number" id="voterNID" name="voterNID">    <!-- input NID number  -->
+                 <button type="submit" class="btn btn-danger" style="margin-left:10px;padding:5px;">Register</button>
+              </div>
+
+            </form>
+            <hr/>
+            <form onsubmit="App.castVote(); return false;" id="votingForm">
               <div class="form-group">
                 <label for="candidatesSelect">Select Candidate </label>
                 <select class="form-control" id="candidatesSelect">

--- a/test/election.js
+++ b/test/election.js
@@ -15,12 +15,24 @@ contract("Election", function(accounts) {
 
   it("initializes with two voters", function() {
     return Election.deployed().then(function(instance) {
-      return instance.votersCount();
-    }).then(function(count) {
-      assert.equal(count, 2);
+       electionInstance = instance;
+        return electionInstance.addVoter(100,{from: accounts[1]});
+    }).then(function(receipt) {
+        assert.equal(receipt.logs.length,1,"an event was triggered");
+        assert.equal(receipt.logs[0].event,"newVoter","the event type is correct");
+        assert.equal(receipt.logs[0].args._nationalID.toNumber(),100,"the candidate id is correct");
+
+        return electionInstance.addVoter(200,{from: accounts[2]});
+      }).then(function(receipt){
+        assert.equal(receipt.logs.length,1,"an event was triggered");
+        assert.equal(receipt.logs[0].event,"newVoter","the event type is correct");
+        assert.equal(receipt.logs[0].args._nationalID.toNumber(),200,"the candidate id is correct");
+        return electionInstance.votersCount();
+      }).then(function(count){
+      assert.equal(count, 2, "contains the correct number of voters");
     });
   });
-  
+
   it("it initializes the candidates with the correct values", function() {
     return Election.deployed().then(function(instance) {
       electionInstance = instance;
@@ -37,20 +49,40 @@ contract("Election", function(accounts) {
     });
   });
 
+  it("it initializes the voters with the correct values", function() {
+    return Election.deployed().then(function(instance) {
+      electionInstance = instance;
+      return electionInstance.voters(accounts[1]);
+    }).then(function(voter) { // (NID, eligibility, hasVoted, BlindedVote, signedBlindedVote)
+      assert.equal(voter[0], 100, "contains the correct NID");
+      assert.equal(voter[1], true, "contains the correct eligibility");
+      assert.equal(voter[2], false, "contains the correct voting state");
+      assert.equal(voter[3], 0, "contains the correct BlindedVote state");
+      assert.equal(voter[4], 0, "contains the correct signedBlindedVote state");
+      return electionInstance.voters(accounts[2]);
+    }).then(function(voter) {
+      assert.equal(voter[0], 200, "contains the correct NID");
+      assert.equal(voter[1], true, "contains the correct eligibility");
+      assert.equal(voter[2], false, "contains the correct voting state");
+      assert.equal(voter[3], 0, "contains the correct BlindedVote state");
+      assert.equal(voter[4], 0, "contains the correct signedBlindedVote state");
+    });
+  });
+
 
 // checks if a vote is casted successfully or not
 it("Successful vote casting by single voter",function(){
     return Election.deployed().then(function(instance){
       electionInstance = instance;
       candidateId = 1;
-      return electionInstance.vote(candidateId, { from: accounts[0]});
+      return electionInstance.vote(candidateId, { from: accounts[1]});
     }).then(function(receipt){
       assert.equal(receipt.logs.length,1,"an event was triggered");
       assert.equal(receipt.logs[0].event,"votedEvent","the event type is correct");
       assert.equal(receipt.logs[0].args._candidateId.toNumber(),candidateId,"the candidate id is correct");
-      return electionInstance.voters(accounts[0]);
-    }).then(function(voted){
-      assert(voted,"the voter was marked as voted");
+      return electionInstance.voters(accounts[1]);
+    }).then(function(voter){
+      assert.equal(voter[2], true, "contains the correct voting state");
       return electionInstance.candidates(candidateId);
     }).then(function(candidate){
       var voteCount = candidate[2];
@@ -82,13 +114,13 @@ it("Double voting exception", function() {
     return Election.deployed().then(function(instance) {
       electionInstance = instance;
       candidateId = 2;
-      electionInstance.vote(candidateId, { from: accounts[1] });
+      electionInstance.vote(candidateId, { from: accounts[2] });
       return electionInstance.candidates(candidateId);
     }).then(function(candidate) {
       var voteCount = candidate[2];
       assert.equal(voteCount, 1, "accepts first vote");
       // Try to vote again
-      return electionInstance.vote(candidateId, { from: accounts[1] });
+      return electionInstance.vote(candidateId, { from: accounts[2] });   //double voting case
     }).then(assert.fail).catch(function(error) {
       assert(error.message.indexOf('revert') >= 0, "error message must contain revert");
       return electionInstance.candidates(1);

--- a/test/election.js
+++ b/test/election.js
@@ -16,18 +16,18 @@ contract("Election", function(accounts) {
   it("initializes with two voters", function() {
     return Election.deployed().then(function(instance) {
        electionInstance = instance;
-        return electionInstance.addVoter(100,{from: accounts[1]});
-    }).then(function(receipt) {
+        return electionInstance.addVoter(100,{from: accounts[1]});  // voter registration with NID-100 by 2nd account from test blockchain
+    }).then(function(receipt) {        // event receipt to check if event was triggered or not
         assert.equal(receipt.logs.length,1,"an event was triggered");
         assert.equal(receipt.logs[0].event,"newVoter","the event type is correct");
         assert.equal(receipt.logs[0].args._nationalID.toNumber(),100,"the candidate id is correct");
 
-        return electionInstance.addVoter(200,{from: accounts[2]});
+        return electionInstance.addVoter(200,{from: accounts[2]});  // voter registration with NID-200 by 2nd account from test blockchain
       }).then(function(receipt){
         assert.equal(receipt.logs.length,1,"an event was triggered");
         assert.equal(receipt.logs[0].event,"newVoter","the event type is correct");
         assert.equal(receipt.logs[0].args._nationalID.toNumber(),200,"the candidate id is correct");
-        return electionInstance.votersCount();
+        return electionInstance.votersCount();      // check total number of voters
       }).then(function(count){
       assert.equal(count, 2, "contains the correct number of voters");
     });
@@ -52,14 +52,14 @@ contract("Election", function(accounts) {
   it("it initializes the voters with the correct values", function() {
     return Election.deployed().then(function(instance) {
       electionInstance = instance;
-      return electionInstance.voters(accounts[1]);
-    }).then(function(voter) { // (NID, eligibility, hasVoted, BlindedVote, signedBlindedVote)
+      return electionInstance.voters(accounts[1]);  // check 2nd account's voter info using its address
+    }).then(function(voter) {         // (NID, eligibility, hasVoted, BlindedVote, signedBlindedVote)
       assert.equal(voter[0], 100, "contains the correct NID");
       assert.equal(voter[1], true, "contains the correct eligibility");
       assert.equal(voter[2], false, "contains the correct voting state");
       assert.equal(voter[3], 0, "contains the correct BlindedVote state");
       assert.equal(voter[4], 0, "contains the correct signedBlindedVote state");
-      return electionInstance.voters(accounts[2]);
+      return electionInstance.voters(accounts[2]);    // check 3rd account's voter info using its address
     }).then(function(voter) {
       assert.equal(voter[0], 200, "contains the correct NID");
       assert.equal(voter[1], true, "contains the correct eligibility");
@@ -75,14 +75,14 @@ it("Successful vote casting by single voter",function(){
     return Election.deployed().then(function(instance){
       electionInstance = instance;
       candidateId = 1;
-      return electionInstance.vote(candidateId, { from: accounts[1]});
+      return electionInstance.vote(candidateId, { from: accounts[1]});    // cast first vote
     }).then(function(receipt){
       assert.equal(receipt.logs.length,1,"an event was triggered");
       assert.equal(receipt.logs[0].event,"votedEvent","the event type is correct");
       assert.equal(receipt.logs[0].args._candidateId.toNumber(),candidateId,"the candidate id is correct");
       return electionInstance.voters(accounts[1]);
     }).then(function(voter){
-      assert.equal(voter[2], true, "contains the correct voting state");
+      assert.equal(voter[2], true, "contains the correct voting state");  // check voter struct's hasVoted value
       return electionInstance.candidates(candidateId);
     }).then(function(candidate){
       var voteCount = candidate[2];
@@ -94,7 +94,7 @@ it("Successful vote casting by single voter",function(){
   it("Invalid candidate voting exception", function() {
   return Election.deployed().then(function(instance) {
     electionInstance = instance;
-    return electionInstance.vote(99, { from: accounts[1] })
+    return electionInstance.vote(99, { from: accounts[1] })   // vote with wrong candidate ID
   }).then(assert.fail).catch(function(error) {
     assert(error.message.indexOf('revert') >= 0, "error message must contain revert");
     return electionInstance.candidates(1);
@@ -114,13 +114,13 @@ it("Double voting exception", function() {
     return Election.deployed().then(function(instance) {
       electionInstance = instance;
       candidateId = 2;
-      electionInstance.vote(candidateId, { from: accounts[2] });
+      electionInstance.vote(candidateId, { from: accounts[2] });      // vote from 3rd account on the blockchain
       return electionInstance.candidates(candidateId);
     }).then(function(candidate) {
       var voteCount = candidate[2];
-      assert.equal(voteCount, 1, "accepts first vote");
+      assert.equal(voteCount, 1, "accepts first vote");   // vote is casted
       // Try to vote again
-      return electionInstance.vote(candidateId, { from: accounts[2] });   //double voting case
+      return electionInstance.vote(candidateId, { from: accounts[2] });   //Try to vote again
     }).then(assert.fail).catch(function(error) {
       assert(error.message.indexOf('revert') >= 0, "error message must contain revert");
       return electionInstance.candidates(1);

--- a/test/election.js
+++ b/test/election.js
@@ -13,6 +13,14 @@ contract("Election", function(accounts) {
     });
   });
 
+  it("initializes with two voters", function() {
+    return Election.deployed().then(function(instance) {
+      return instance.votersCount();
+    }).then(function(count) {
+      assert.equal(count, 2);
+    });
+  });
+  
   it("it initializes the candidates with the correct values", function() {
     return Election.deployed().then(function(instance) {
       electionInstance = instance;


### PR DESCRIPTION
# Voter Registration Functionality - Solves Issue #16 

## Prior to ECDSA feature implementation, **voter registration feature** has been implemented carefully so vote blinding and signing process can be properly integrated.

- The feature ensures that the voters are authentic and identifiable
- Front end has a registration section with **"Enter NID Number"** field and **"Register"** button.
- Before election, voters need to register with their **NID (National Identification Number)** through the UI. **They can not vote without registration.**
- **Anyone** can register as voter prior to the election (for simplicity).
- **One can not register twice as a voter.** Voter must have only one **address** associated with govt issued NID number. (This ensures voter is unique)
-  On *election.sol* contract, there are following changes -
    1. **Voter struct** with properties - 
        -  **NID** : Govt issued national identification number of candidate
        -  **Eligibility** : Stores the valid list of voters during registration
        -  **Flag hasVoted** : Flag updates when vote is successfully casted on the blockchain
        -  **Blinded Vote** : stores voter's hashed(blinded) vote
        -  **Signed Blinded Vote** : blind signature of the vote
    2. *addVoter(NID)* function 
- In compliance with the contract, *app.js*, *index.html* and *election.js* has been changed accordingly
- Newly added tests to ensure this feature is working properly -
    - Initializes with two voters
    - Initializes the voters with the correct values

## Types of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How Has This Been Tested?

1. Run `$ truffle migrate --reset` to migrate the contracts as fresh ones and then `$ truffle test` to check the result of all the tests.

![test](https://user-images.githubusercontent.com/42487891/89715995-88818700-d9cb-11ea-81fe-9a3a85d3c1f7.png)

2. Run `'$ npm run dev'`, open browser with **MetaMask** activated and connect with an account with sufficient Ethers.
The UI  would display -
![1](https://user-images.githubusercontent.com/42487891/89716179-b5826980-d9cc-11ea-8eae-90ae2ae6ba06.png)

3. Note that user has not registered and can't vote right now. 
Now register with an NID -
![2](https://user-images.githubusercontent.com/42487891/89716192-d5199200-d9cc-11ea-98bb-92c068fbe552.png)

4. You will have the voting options visible now and see a change in registered voter's count. 
Now vote a candidate - 
![3](https://user-images.githubusercontent.com/42487891/89716229-1c078780-d9cd-11ea-918b-c00f5feb71dc.png)

5.Candidate count will update. Now switch to another valid unregistered account and register again with another sample NID -

![4](https://user-images.githubusercontent.com/42487891/89716276-730d5c80-d9cd-11ea-890c-629053110a97.png)

The changes will be visible and you will be able to cast a single vote again.

## Successful Tests
- [x] `Initializes with two voters`
- [x] `initializes with two candidates`
- [x] `it initializes the candidates with the correct values`
- [x] `Initializes the voters with the correct values`
- [x] `Successful vote casting by single voter`
- [x] `Invalid candidate voting exception`
- [x] `Double voting exception`

## Test Configuration:
* Firmware version: Win 10 64 bit
* Hardware: Intel Core i5 4460
* Truffle : v5.1.10 (core: 5.1.10)
* Solidity - 0.4.23 (solc-js)
* Node - v12.18.2
* Web3.js - v1.2.1


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
