### PR TITLE
Candidates List Replication Issue Fix

### DIFF
--- a/build/contracts/Election.json
+++ b/build/contracts/Election.json
@@ -4758,12 +4758,12 @@
         }
       },
       "links": {},
-      "address": "0x6017aa4De7F59FADB82336eCe743424fb51F3Dc8",
-      "transactionHash": "0x3192e5cd46fdd5916f130975a20f8afc3a51a781bb44fa0c27d073d10394440e"
+      "address": "0xcE4519FCe6a6a00c8c355E8558C20Fd080339D4a",
+      "transactionHash": "0x718ee6268e1884aef8dd3541ce04483c46d244c5178e40718690e7a2c2551ddd"
     }
   },
   "schemaVersion": "3.0.22",
-  "updatedAt": "2020-08-08T16:38:26.053Z",
+  "updatedAt": "2020-08-09T13:24:08.833Z",
   "networkType": "ethereum",
   "devdoc": {
     "methods": {}

--- a/build/contracts/Migrations.json
+++ b/build/contracts/Migrations.json
@@ -1379,12 +1379,12 @@
     "5777": {
       "events": {},
       "links": {},
-      "address": "0x13a2808b538E8f34364099e782F4a584899BB80a",
-      "transactionHash": "0x40f8773f351fd8ecda5134eb738e30b096c6907fd1dadd8ecdb4e48b38861019"
+      "address": "0xdb8531676A79694d3997F6a1ebAE6696c784E915",
+      "transactionHash": "0xc10fd365be17510ca051f73eefe46447d6382d201c729c2aefc4d02fa47ddc2c"
     }
   },
   "schemaVersion": "3.0.22",
-  "updatedAt": "2020-08-08T16:38:26.056Z",
+  "updatedAt": "2020-08-09T13:24:08.835Z",
   "networkType": "ethereum",
   "devdoc": {
     "methods": {}

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -26,8 +26,8 @@ App = {
       App.contracts.Election = TruffleContract(election);
       // Connect provider to interact with contract
       App.contracts.Election.setProvider(App.web3Provider);
-     App.listenForEvents();  // event listener call
-    App.listenForNewVoterEvent();
+     App.listenForEvents();  // event listener call for votecasting event
+    App.listenForNewVoterEvent(); // event listener call for new voter registration
       return App.render();
     });
   },
@@ -40,8 +40,6 @@ App = {
         toBlock: 'latest'
       }).watch(function(error,event){
         console.log("voting event triggered",event);
-        //Reload when a new vote is recorded
-        App.render();
       })
     })
   },
@@ -53,8 +51,6 @@ App = {
           toBlock: 'latest'
         }).watch(function(error,event){
           console.log("new voter event triggered",event);
-          //Reload when a new vote is recorded
-          App.render();
         })
       })
   },
@@ -137,6 +133,8 @@ castVote: function() {    // function is called  during vote casting
       // Wait for votes to update
       $("#content").hide();
       $("#loader").show();
+      //Reload everything when a new vote is recorded
+     App.init();
     }).catch(function(err) {
       console.error(err);
     });
@@ -151,6 +149,9 @@ createVoter: function() {   // function is called  during voter registration
         // Wait for votes to update
         $("#content").hide();
         $("#loader").show();
+
+        //Reload everything when a new voter is created
+        App.init();
       }).catch(function(err) {
         console.error(err);
       });


### PR DESCRIPTION
# Candidates List Replication Fix - Solves Issue #18  

## Made some adjustments over app.js script to stop candidates list replicating twice during voter registration, vote casting or wallet account switching.

-  Added _App.init()_ function calls for each user generated event (_Voter registration_ and _Candidate vote cast_).
- Removed _App.render()_ function call from each event listener functions.

## Types of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Run `$ truffle migrate --reset` to migrate the contracts as fresh ones and then `$ truffle test` to check the result of all the tests.
2. Run `'$ npm run dev'`, open browser with **MetaMask** activated and connect with an account with sufficient Ethers.
3. Note that there are two candidates visible. 
Now register and vote for one.
4. When you register or cast vote, the UI will reload and you will not find any visible change in the number of candidates.
It will remain same.

## Test Configuration:
* Firmware version: Win 10 64 bit
* Hardware: Intel Core i5 4460
* Truffle : v5.1.10 (core: 5.1.10)
* Solidity - 0.4.23 (solc-js)
* Node - v12.18.2
* Web3.js - v1.2.1

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

